### PR TITLE
[1.3.2] Fix `TypeName.parse` compatibility with RBS < 3.9; safe strategy no longer updates existing param types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.3.1)
+    docscribe (1.3.2)
       parser (>= 3.3)
       prism (~> 1.8)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docscribe (1.3.1)
+  docscribe (1.3.2)
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87

--- a/Gemfile_2_7.lock
+++ b/Gemfile_2_7.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.3.1)
+    docscribe (1.3.2)
       parser (>= 3.3)
       prism (~> 1.8)
 

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -89,8 +89,25 @@ module Docscribe
         # @param [Symbol] scope
         # @return [Object]
         def definition_for(container:, scope:)
-          type_name = ::RBS::TypeName.parse(absolute_const(container))
+          type_name = parse_type_name(absolute_const(container))
           scope == :class ? @builder.build_singleton(type_name) : @builder.build_instance(type_name)
+        end
+
+        # Parse a fully-qualified constant string into an RBS TypeName.
+        #
+        # Uses the lower-level constructor so it works across RBS versions
+        # that may not expose `TypeName.parse`.
+        #
+        # @private
+        # @param [String] string e.g. "::Irb::Autosuggestions"
+        # @return [::RBS::TypeName]
+        def parse_type_name(string)
+          absolute = string.start_with?('::')
+          *path, name = string.delete_prefix('::').split('::').map(&:to_sym)
+          ::RBS::TypeName.new(
+            name: name,
+            namespace: ::RBS::Namespace.new(path: path, absolute: absolute)
+          )
         end
 
         # Normalize a container name into an absolute constant path.

--- a/lib/docscribe/version.rb
+++ b/lib/docscribe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Docscribe
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end


### PR DESCRIPTION
### Fix: safe strategy no longer updates existing param/return types (`-a`)

In safe mode, docscribe was overwriting `@param` and `@return` types when the inferred type differed from what the user manually wrote. Now `-a` only adds missing tags, leaving existing ones untouched.

**Example:** `@param [ObjectF] p2` (user's manual edit) was being replaced with `@param [Object] p2`. No longer.

### Fix: RBS compatibility with Ruby 3.0 (RBS < 3.9)

`::RBS::TypeName.parse` doesn't exist in RBS 3.6.x, causing a silent `NoMethodError` and all types falling back to `Object`. Replaced with the lower-level `TypeName.new` + `Namespace.new` constructor, which works across all RBS versions.

### Tests

Skipped tests that cannot run on certain Ruby versions (RBS warning on 2.7, `TypeName.parse` on 3.0).