### PR TITLE
[1.3.3] RBS collection report mismatches

### DIFF
--- a/.github/workflows/check-source-branch.yml
+++ b/.github/workflows/check-source-branch.yml
@@ -1,0 +1,14 @@
+name: Check source branch
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ ! "${{ github.head_ref }}" =~ ^v ]]; then
+            echo "PRs in master allowed only from v* branches"
+            exit 1
+          fi

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.3.2)
+    docscribe (1.3.3)
       parser (>= 3.3)
       prism (~> 1.8)
 
@@ -86,7 +86,7 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   bundler (4.0.11) sha256=5bcec0fb78302e48d02ee46f10ee6e6942be647ba5b44a6d1ddfda9a240ce785
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docscribe (1.3.2)
+  docscribe (1.3.3)
   json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87

--- a/Gemfile_2_7.lock
+++ b/Gemfile_2_7.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.3.2)
+    docscribe (1.3.3)
       parser (>= 3.3)
       prism (~> 1.8)
 

--- a/lib/docscribe/cli/config_builder.rb
+++ b/lib/docscribe/cli/config_builder.rb
@@ -53,7 +53,7 @@ module Docscribe
             require 'docscribe/types/rbs/collection_loader'
             collection_path = Docscribe::Types::RBS::CollectionLoader.resolve
             if collection_path
-              raw['rbs']['sig_dirs'] = Array(raw['rbs']['sig_dirs']) + [collection_path]
+              raw['rbs']['collection_dirs'] = Array(raw['rbs']['collection_dirs']) + [collection_path]
             else
               warn 'Docscribe: rbs_collection.lock.yaml not found or collection not installed. ' \
                    'Run `bundle exec rbs collection install` first.'

--- a/lib/docscribe/config/defaults.rb
+++ b/lib/docscribe/config/defaults.rb
@@ -62,6 +62,7 @@ module Docscribe
         'enabled' => false,
         'collection' => false,
         'sig_dirs' => ['sig'],
+        'collection_dirs' => [],
         'collapse_generics' => false
       },
       'sorbet' => {

--- a/lib/docscribe/config/rbs.rb
+++ b/lib/docscribe/config/rbs.rb
@@ -17,6 +17,7 @@ module Docscribe
         require 'docscribe/types/rbs/provider'
         Docscribe::Types::RBS::Provider.new(
           sig_dirs: rbs_sig_dirs,
+          collection_dirs: rbs_collection_dirs,
           collapse_generics: rbs_collapse_generics?
         )
       rescue LoadError
@@ -71,6 +72,18 @@ module Docscribe
     # @return [Array<String>]
     def rbs_sig_dirs
       Array(raw.dig('rbs', 'sig_dirs') || DEFAULT.dig('rbs', 'sig_dirs')).map(&:to_s)
+    end
+
+    # RBS collection directories (auto-discovered from rbs_collection.lock.yaml).
+    #
+    # Loaded separately from user sig_dirs so that collection-related
+    # RBS environment errors (e.g. duplicate declarations against core
+    # stdlib types) do not silence all RBS lookups.
+    #
+    # @private
+    # @return [Array<String>]
+    def rbs_collection_dirs
+      Array(raw.dig('rbs', 'collection_dirs')).map(&:to_s)
     end
 
     # Whether generic RBS types should be collapsed to simpler container names.

--- a/lib/docscribe/config/template.rb
+++ b/lib/docscribe/config/template.rb
@@ -86,6 +86,7 @@ module Docscribe
           # Use RBS signatures for better types (requires `gem "rbs"`)
           enabled: false
           sig_dirs: ["sig"]
+          collection_dirs: []                 # auto-discovered from --rbs-collection
           collapse_generics: false            # Hash<Symbol, String> => Hash
           collection: false                   # auto-discover from rbs_collection.lock.yaml
 

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -15,16 +15,21 @@ module Docscribe
       # the pipeline can stay independent of the underlying signature source.
       class Provider
         # @param [Array<String>] sig_dirs directories containing `.rbs` files
+        # @param [Array<String>] collection_dirs RBS collection directories
+        #   (loaded separately; on error they are silently dropped and only
+        #   user sig_dirs are used)
         # @param [Boolean] collapse_generics whether generic container types
         #   should be simplified during formatting
         # @return [Object]
-        def initialize(sig_dirs:, collapse_generics: false)
+        def initialize(sig_dirs:, collection_dirs: [], collapse_generics: false)
           require 'rbs'
           @sig_dirs = Array(sig_dirs).map(&:to_s)
+          @collection_dirs = Array(collection_dirs).map(&:to_s)
           @collapse_generics = !!collapse_generics
           @env = nil
           @builder = nil
           @warned = false
+          @collection_dropped = false
         end
 
         # Look up a normalized method signature from loaded RBS definitions.
@@ -64,22 +69,46 @@ module Docscribe
 
         # Lazily load and resolve the RBS environment.
         #
+        # Tries to load collection dirs together with user sig_dirs.
+        # If the combined environment raises a load error (e.g. duplicate
+        # declarations between collection and core stdlib types), collection
+        # dirs are dropped and only user sig_dirs are used.
+        #
         # @private
         # @return [void]
         def load_env!
           return if @env && @builder
 
+          @env = build_env(@sig_dirs + @collection_dirs)
+        rescue ::RBS::BaseError => e
+          raise unless @collection_dirs.any? && !@collection_dropped
+
+          @collection_dropped = true
+          if ENV['DOCSCRIBE_RBS_DEBUG'] == '1'
+            warn "Docscribe: RBS collection error (#{e.class}), dropping collection dirs. " \
+                 'Set DOCSCRIBE_RBS_DEBUG=1 for details.'
+          end
+          @env = build_env(@sig_dirs)
+        end
+
+        # Build an RBS environment from the given directories.
+        #
+        # @private
+        # @param [Array<String>] dirs
+        # @return [::RBS::Environment]
+        def build_env(dirs)
           loader = ::RBS::EnvironmentLoader.new
           # Load core types transitively
           loader.add(library: 'rbs')
 
-          @sig_dirs.each do |dir|
+          dirs.each do |dir|
             path = Pathname(dir)
             loader.add(path: path) if path.directory?
           end
 
-          @env = ::RBS::Environment.from_loader(loader).resolve_type_names
-          @builder = ::RBS::DefinitionBuilder.new(env: @env)
+          env = ::RBS::Environment.from_loader(loader).resolve_type_names
+          @builder = ::RBS::DefinitionBuilder.new(env: env)
+          env
         end
 
         # Build the appropriate instance or singleton definition for a container.

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -75,6 +75,8 @@ module Docscribe
         # dirs are dropped and only user sig_dirs are used.
         #
         # @private
+        # @raise [::RBS::BaseError]
+        # @raise [StandardError]
         # @return [void]
         def load_env!
           return if @env && @builder

--- a/lib/docscribe/version.rb
+++ b/lib/docscribe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Docscribe
-  VERSION = '1.3.2'
+  VERSION = '1.3.3'
 end


### PR DESCRIPTION
**Fixed `--rbs-collection` not reporting type mismatches**

`--rbs-collection` added `.gem_rbs_collection/` to RBS `sig_dirs`, but collection signatures for stdlib gems (e.g. `logger`) duplicate core RBS types. RBS 3.6.1 raises `DuplicatedDeclarationError`, which was silently caught by `signature_for`'s rescue — causing all RBS lookups to return nil. Result: zero mismatches reported.

**Changes:**

- **`config_builder.rb`** — store collection path in `collection_dirs` (separate from user `sig_dirs`)
- **`provider.rb`** — `load_env!` tries all dirs; on `RBS::BaseError` falls back to user `sig_dirs` only
- **`config/rbs.rb`** — new `rbs_collection_dirs` method, passes it to `Provider`
- **`defaults.rb`**, **`template.rb`** — added `collection_dirs: []` default
- Collection path is now stored separately from user sig_dirs to prevent collection-related RBS errors from poisoning the entire environment.