### PR TITLE
[v1.4.1] Fix `--include` glob pattern routing, `ModelAttributes` multi-model + `truncate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.1 (unreleased)
+## 1.4.1
 
 ### Added
 
@@ -13,11 +13,15 @@
 
 - `build_override_plugin` test helper not forwarding `tags` to constructor
 - `rewrite_with_report` default `config:` (`nil` instead of `Docscribe::Config.new({})`)
+- `--include '*/get'` glob pattern now correctly routes as method filter instead of file filter
+- `match_pattern?` translates `/` to `#` in glob patterns so `*/get` matches `ApiClient#get`
+- ModelAttributes `build_method_docs` processes each class with its own table columns instead of using the first model's columns for the entire AST
 
 ### Changed
 
 - ModelAttributes plugin converted from `doc:` to `method_override:` (dead code removed)
 - ModelAttributes plugin now supports `defs` (class methods) and works with aggressive mode
+- ModelAttributes `string_method?` / `infer_string_method_type` now includes `truncate`
 
 ## 1.4.0 (2026-05-30)
 

--- a/examples/plugins/collector_plugin/model_attributes/plugin.rb
+++ b/examples/plugins/collector_plugin/model_attributes/plugin.rb
@@ -49,8 +49,7 @@ module DocscribePlugins
     # Walk the AST and return doc insertion targets for model methods.
     #
     # @param [Parser::AST::Node] ast
-    # @param [Parser::Source::Buffer] buffer
-    # @param [Object] _buffer Param documentation.
+    # @param [Parser::Source::Buffer] _buffer Param documentation.
     # @return [Array<Hash>]
     def collect(ast, _buffer)
       return [] unless active_record_model?(ast)
@@ -58,14 +57,7 @@ module DocscribePlugins
       tables = load_schema!
       return [] if tables.empty?
 
-      model_name = extract_model_name(ast)
-      return [] unless model_name
-
-      table_name = model_name_to_table_name(model_name)
-      columns = tables[table_name]
-      return [] unless columns
-
-      build_method_docs(ast, table_name, columns)
+      build_method_docs(ast, tables)
     end
 
     private
@@ -191,18 +183,26 @@ module DocscribePlugins
       @schema_tables = {}
     end
 
-    # Build doc blocks for methods in a model class.
+    # Build doc blocks for methods in all model classes.
+    #
+    # Each class gets its own table's column mapping.
     #
     # @private
     # @param [Parser::AST::Node] ast
-    # @param [String] _table_name
-    # @param [Hash{String => String}] columns
+    # @param [Hash{String => Hash{String => String}}] tables
     # @return [Array<Hash>]
-    def build_method_docs(ast, _table_name, columns)
+    def build_method_docs(ast, tables)
       results = []
 
       Docscribe::Infer::ASTWalk.walk(ast) do |node|
         next unless node.type == :class
+
+        model_name = resolve_const_name(node.children[0])
+        next unless model_name
+
+        table_name = model_name_to_table_name(model_name)
+        columns = tables[table_name]
+        next unless columns
 
         _name, _parent, body = *node
         next unless body
@@ -392,6 +392,7 @@ module DocscribePlugins
         upcase downcase capitalize capitalize_first
         strip lstrip rstrip
         trim gsub sub gsub! sub!
+        truncate
         concat append +
         split chars each_char each_line
         include? start_with? end_with?
@@ -465,6 +466,7 @@ module DocscribePlugins
         upcase downcase capitalize
         strip lstrip rstrip
         gsub sub
+        truncate
         concat append +
         include? start_with? end_with?
         match scan

--- a/lib/docscribe/cli/options.rb
+++ b/lib/docscribe/cli/options.rb
@@ -203,6 +203,7 @@ module Docscribe
       # @return [Boolean]
       def looks_like_file_pattern?(pat)
         return false if pat.start_with?('/') && pat.end_with?('/') && pat.length >= 2
+        return false if pat.match?(%r{\A\*/})
 
         pat.include?('/') || pat.include?('**') || pat.end_with?('.rb')
       end

--- a/lib/docscribe/config/utils.rb
+++ b/lib/docscribe/config/utils.rb
@@ -65,7 +65,7 @@ module Docscribe
     #
     # Supports:
     # - `/regex/`
-    # - shell-style glob patterns
+    # - shell-style glob patterns (with `/` translated to `#` since method IDs use `#`)
     #
     # @private
     # @param [String] pattern
@@ -75,7 +75,7 @@ module Docscribe
       if pattern.start_with?('/') && pattern.end_with?('/') && pattern.length >= 2
         Regexp.new(pattern[1..-2]).match?(text)
       else
-        File.fnmatch?(pattern, text, File::FNM_EXTGLOB)
+        File.fnmatch?(pattern.tr('/', '#'), text, File::FNM_EXTGLOB)
       end
     end
 


### PR DESCRIPTION
Three fixes:

- **`--include */get` routing** — `looks_like_file_pattern?` no longer routes `*/`-prefixed patterns as file filters; `match_pattern?` translates `/` -> `#` so `*/get` matches method ID `ApiClient#get`
- **ModelAttributes multi-model** — each class node resolves its own table columns instead of using the first model columns for the entire AST (fixes `published?` in `Post` showing `Object`)
- **`truncate` added** to `string_method?` / `infer_string_method_type` so `bio.to_s.truncate(100)` resolves to `String` instead of `Object`