### PR TITLE
[1.5.1] Server/daemon mode, env invalidation, LRU cache, config fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## 1.5.1
+
+### Added
+
+- **Server/daemon mode** (`docscribe server`):
+    - Start/stop/status subcommand for a persistent background daemon.
+    - JSON-RPC 2.0 protocol over Unix socket (`check`, `fix`, `shutdown`).
+    - Idle timeout (5 minutes) — daemon auto-exits after inactivity.
+    - `--server` flag for existing `docscribe` commands to use the daemon transparently.
+- **`docscribe-client`** — standalone thin client (`exe/docscribe-client`) for IDE plugins
+  and CI. Connects to the daemon without loading the full docscribe gem.
+- **Env invalidation:** daemon socket path includes mtime of `Gemfile.lock` and
+  `rbs_collection.lock.yaml`. Environment changes spawn a fresh daemon automatically.
+- **LRU file cache:** `Docscribe::LRUCache` (bounded at 1000 entries) caches parsed
+  results per file by mtime, serving repeated checks nearly instantly.
+- **Rescue-aware type inference for parameters:**
+    - `handle_lvar_node` now uses `lookup_lvar_type` which checks both
+      `local_var_types` and `param_types` — rescue body returning a parameter
+      defaults to the correct type instead of `Object`.
+- **Rescue-aware type inference for explicit receivers:**
+    - `resolve_rbs_for_send` falls back to `signature_provider` (project RBS)
+      when `core_rbs_provider` fails — enables type resolution for method calls
+      on explicit receivers in rescue bodies.
+
+### Fixed
+
+- **CLI override leak in daemon:** `apply_cli_overrides` now resets
+  `@effective_config`, `@applied_overrides`, and clears `@file_cache` when
+  overrides are `nil` or empty. Previously, stale overrides from a prior
+  request leaked into subsequent requests with no overrides.
+- **Duplicate `@return` tag in aggressive mode with rescue:** `merge_existing_descriptions!`
+  no longer treats machine-generated conditional annotations (e.g. `"if RuntimeError"`)
+  as human-written descriptions — skips `return_description` starting with `"if "`.
+- **RuboCop compliance:** 2 → 0 offenses in `lib/docscribe/infer/returns.rb`:
+  extracted `resolve_rbs_for_send_with_signature_provider` to fix
+  `Metrics/MethodLength` and `Metrics/ParameterLists`.
+- **RBS/Steep:** added signature for `resolve_rbs_for_send_with_signature_provider`.
+
+### Changed
+
+- **README updated:** new Server mode section documenting daemon, thin client,
+  env invalidation, LRU cache, CLI override handling.
+- **Editor Integration section** updated to reference `docscribe-client` and daemon.
+
 ## 1.5.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,42 +4,51 @@
 
 - **Server/daemon mode** (`docscribe server`):
     - Start/stop/status subcommand for a persistent background daemon.
-    - JSON-RPC 2.0 protocol over Unix socket (`check`, `fix`, `shutdown`).
+    - JSON-RPC 2.0 protocol over Unix socket (`check`, `fix`, `shutdown`, `ping`).
     - Idle timeout (5 minutes) — daemon auto-exits after inactivity.
     - `--server` flag for existing `docscribe` commands to use the daemon transparently.
 - **`docscribe-client`** — standalone thin client (`exe/docscribe-client`) for IDE plugins
   and CI. Connects to the daemon without loading the full docscribe gem.
-- **Env invalidation:** daemon socket path includes mtime of `Gemfile.lock` and
-  `rbs_collection.lock.yaml`. Environment changes spawn a fresh daemon automatically.
-- **LRU file cache:** `Docscribe::LRUCache` (bounded at 1000 entries) caches parsed
-  results per file by mtime, serving repeated checks nearly instantly.
+    - `--status` flag to check if the daemon is running (exit code 0/1).
+    - `--ping` flag to get version, pid, uptime, and socket path from the daemon.
+- **Env invalidation:** daemon socket path includes mtime of `Gemfile.lock` and `rbs_collection.lock.yaml`. Environment
+  changes spawn a fresh daemon automatically.
+- **LRU file cache:** `Docscribe::LRUCache` (bounded at 1000 entries) caches parsed results per file by mtime, serving
+  repeated checks nearly instantly.
 - **Rescue-aware type inference for parameters:**
-    - `handle_lvar_node` now uses `lookup_lvar_type` which checks both
-      `local_var_types` and `param_types` — rescue body returning a parameter
-      defaults to the correct type instead of `Object`.
+    - `handle_lvar_node` now uses `lookup_lvar_type` which checks both `local_var_types` and `param_types` — rescue body
+      returning a parameter defaults to the correct type instead of `Object`.
 - **Rescue-aware type inference for explicit receivers:**
-    - `resolve_rbs_for_send` falls back to `signature_provider` (project RBS)
-      when `core_rbs_provider` fails — enables type resolution for method calls
-      on explicit receivers in rescue bodies.
+    - `resolve_rbs_for_send` falls back to `signature_provider` (project RBS) when `core_rbs_provider` fails — enables
+      type resolution for method calls on explicit receivers in rescue bodies.
+- **RBS Provider stdlib loading:** `Provider` now loads stdlib libraries (`socket`, `json`, `digest`, etc.) from
+  `rbs_collection.lock.yaml`, enabling correct resolution of RBS files that reference stdlib types (e.g. `UNIXSocket`).
 
 ### Fixed
 
-- **CLI override leak in daemon:** `apply_cli_overrides` now resets
-  `@effective_config`, `@applied_overrides`, and clears `@file_cache` when
-  overrides are `nil` or empty. Previously, stale overrides from a prior
-  request leaked into subsequent requests with no overrides.
-- **Duplicate `@return` tag in aggressive mode with rescue:** `merge_existing_descriptions!`
-  no longer treats machine-generated conditional annotations (e.g. `"if RuntimeError"`)
-  as human-written descriptions — skips `return_description` starting with `"if "`.
-- **RuboCop compliance:** 2 → 0 offenses in `lib/docscribe/infer/returns.rb`:
-  extracted `resolve_rbs_for_send_with_signature_provider` to fix
-  `Metrics/MethodLength` and `Metrics/ParameterLists`.
+- **CLI override leak in daemon:** `apply_cli_overrides` now resets `@effective_config`, `@applied_overrides`, and
+  clears `@file_cache` when overrides are `nil` or empty. Previously, stale overrides from a prior request leaked into
+  subsequent requests with no overrides.
+- **Duplicate `@return` tag in aggressive mode with rescue:** `merge_existing_descriptions!` no longer treats
+  machine-generated conditional annotations (e.g. `"if RuntimeError"`) as human-written descriptions — skips
+  `return_description` starting with `"if "`.
+- **RuboCop compliance:** 2 -> 0 offenses in `lib/docscribe/infer/returns.rb`: extracted
+  `resolve_rbs_for_send_with_signature_provider` to fix `Metrics/MethodLength` and `Metrics/ParameterLists`.
 - **RBS/Steep:** added signature for `resolve_rbs_for_send_with_signature_provider`.
+- **RBS Provider silently returning `Object` for all lookups:** `Provider` failed to load stdlib RBS libraries (
+  `socket`, `json`, etc.), causing `NoTypeFoundError` on any sig referencing stdlib types. All `signature_for` calls
+  fell back to inference which returned `Object`, silently breaking `docscribe update_types`.
+- **Unix socket path exceeding OS limit on macOS:** `Dir.tmpdir` returns a long path under `/var/folders/.../T`, causing
+  `ArgumentError: too long unix socket path` (max 104 bytes). The daemon crashed silently on startup. Fixed by falling
+  back to `/tmp` when `Dir.tmpdir` exceeds the socket path length limit.
 
 ### Changed
 
-- **README updated:** new Server mode section documenting daemon, thin client,
-  env invalidation, LRU cache, CLI override handling.
+- **`docscribe server status` now uses `ping` protocol** for extended info: version, pid, socket path, uptime.
+- **Daemon auto-start no longer prints to stderr:** the `"Docscribe: starting server..."` message is only emitted on
+  explicit `docscribe server start`, not on implicit auto-start via `--server`.
+- **README updated:** new Server mode section documenting daemon, thin client, env invalidation, LRU cache, CLI override
+  handling, ping protocol.
 - **Editor Integration section** updated to reference `docscribe-client` and daemon.
 
 ## 1.5.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.5.0)
+    docscribe (1.5.1)
       parser (>= 3.3)
       prism (~> 1.8)
 
@@ -131,7 +131,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docscribe (1.5.0)
+  docscribe (1.5.1)
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02

--- a/Gemfile_2_7.lock
+++ b/Gemfile_2_7.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.5.0)
+    docscribe (1.5.1)
       parser (>= 3.3)
       prism (~> 1.8)
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# Docscribe
+<p align="center">
+  <img src="assets/icons/icon_128x128.png" alt="Docscribe logo" width="128">
+</p>
 
-[![Gem Version](https://img.shields.io/gem/v/docscribe.svg)](https://rubygems.org/gems/docscribe)
-[![RubyGems Downloads](https://img.shields.io/gem/dt/docscribe.svg)](https://rubygems.org/gems/docscribe)
-[![CI](https://github.com/unurgunite/docscribe/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/unurgunite/docscribe/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/unurgunite/docscribe.svg)](https://github.com/unurgunite/docscribe/blob/master/LICENSE.txt)
-[![Ruby](https://img.shields.io/badge/ruby-%3E%3D%202.7-blue.svg)](#installation)
-[![VS Code](https://img.shields.io/badge/VS%20Code-plugin-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=unurgunite.docscribe-vscode)
-[![RubyMine](https://img.shields.io/badge/RubyMine-plugin-green?logo=jetbrains)](https://plugins.jetbrains.com/plugin/32349-docscribe)
+<h1 align="center">DocScribe</h1>
 
-<p>
-  <img src="assets/icons/icon_256x256.png" alt="Docscribe logo" width="96">
+<p align="center">
+<a href="https://rubygems.org/gems/docscribe"><img src="https://img.shields.io/gem/v/docscribe.svg" alt="Gem Version"></a>
+<a href="https://rubygems.org/gems/docscribe"><img src="https://img.shields.io/gem/dt/docscribe.svg" alt="RubyGems Downloads"></a>
+<a href="https://github.com/unurgunite/docscribe/actions/workflows/ci.yml"><img src="https://github.com/unurgunite/docscribe/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI"></a>
+<a href="https://github.com/unurgunite/docscribe/blob/master/LICENSE.txt"><img src="https://img.shields.io/github/license/unurgunite/docscribe.svg" alt="License"></a>
+<a href="#installation"><img src="https://img.shields.io/badge/ruby-%3E%3D%202.7-blue.svg" alt="Ruby"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=unurgunite.docscribe-vscode"><img src="https://img.shields.io/badge/VS%20Code-plugin-blue?logo=visualstudiocode" alt="VS Code"></a>
+<a href="https://plugins.jetbrains.com/plugin/32349-docscribe"><img src="https://img.shields.io/badge/RubyMine-plugin-green?logo=jetbrains" alt="RubyMine"></a>
 </p>
 
 ![Docscribe before/after demo](docs/image.png)
@@ -673,7 +675,7 @@ docscribe -a --server lib
 2. The socket path is derived from the project root, `Gemfile.lock` mtime, and `rbs_collection.lock.yaml` mtime — so any
    environment change spawns a fresh daemon automatically.
 3. Client requests (`docscribe --server`) send JSON-RPC 2.0 messages over the socket: `check` (inspect), `fix` (apply
-   changes), and `shutdown`.
+   changes), `shutdown`, and `ping` (health/version info).
 4. The daemon holds a reusable `Docscribe::Config` instance and an LRU file cache (bounded at 1000 entries), so repeated
    checks on the same files are nearly instant.
 5. After 5 minutes of inactivity the daemon shuts down automatically.
@@ -686,13 +688,19 @@ gem:
 
 ```shell
 # Check a file via the daemon
-docscribe-client check lib/user.rb
+docscribe-client --check lib/user.rb
 
 # Apply fixes via the daemon
-docscribe-client fix lib/user.rb
+docscribe-client --fix lib/user.rb
+
+# Check if the daemon is running
+docscribe-client --status
+
+# Get version, pid, uptime from the daemon
+docscribe-client --ping
 
 # Stop the daemon
-docscribe-client shutdown
+docscribe-client --shutdown
 ```
 
 The thin client is used automatically by

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ docscribe -A lib
         * [`docscribe rbs` — generate RBS from YARD](#docscribe-rbs--generate-rbs-from-yard)
         * [`docscribe update_types` — two-pass type-aware documentation update](#docscribe-update_types--two-pass-type-aware-documentation-update)
         * [`docscribe check_for_comments` — find placeholder documentation](#docscribe-check_for_comments--find-placeholder-documentation)
+        * [`docscribe server` — persistent daemon mode](#docscribe-server--persistent-daemon-mode)
     * [Update strategies](#update-strategies)
         * [Safe strategy](#safe-strategy)
         * [Aggressive strategy](#aggressive-strategy)
@@ -166,6 +167,10 @@ loading, then delegates to the core engine which parses source code, collects me
 doc lines — combining heuristic type inference, external RBS/Sorbet signatures, and plugin output — and finally rewrites
 the source via a strategy (safe merge or aggressive replace).
 
+In server mode, a persistent daemon (`docscribe server`) keeps the runtime loaded and caches parsed results across
+invocations via an LRU cache, enabling near-instant repeated checks for IDE plugins. A thin client (`docscribe-client`)
+provides minimal-overhead socket communication without loading the full gem.
+
 ```mermaid
 flowchart TB
     subgraph CLI["CLI Layer"]
@@ -240,7 +245,18 @@ flowchart TB
         YTypes["Yard::Types\n9 AST node types\n(Named, Generic, etc.)"]
     end
 
+    subgraph Server["Server / Daemon"]
+        ThinClient["exe/docscribe-client\nThin client\n· socket send/receive\n· no gem load"]
+        ServerDaemon["Server::Daemon\nSocket listener\n· check / fix / shutdown\n· JSON-RPC 2.0"]
+        Cache["Docscribe::LRUCache\nFile result cache\n(max 1000, by mtime)"]
+    end
+
     Exe --> Run
+    Exe --> ServerDaemon
+    ThinClient --> ServerDaemon
+    ServerDaemon --> ConfigClass
+    ServerDaemon --> Cache
+    ServerDaemon --> InlineRewriter
     Run --> Options
     Run --> InitCmd
     Run --> GenCmd
@@ -249,6 +265,7 @@ flowchart TB
     Run --> SarifFormatter
     Run --> ConfigBuilder
     ConfigBuilder --> ConfigClass
+    ConfigBuilder --> ServerDaemon
     ConfigClass --> Defaults
     ConfigClass --> Loader
     ConfigClass --> Emit
@@ -298,7 +315,25 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    Input["Source files\n(.rb)"] --> Parse["Parsing.parse_buffer\nParser gem / Prism"]
+    subgraph Entry["Entry Points"]
+        Direct["docscribe lib\n(no --server)"]
+        ViaServer["docscribe --server\nor docscribe-client"]
+    end
+
+    subgraph Daemon["Server Daemon (Unix Socket)"]
+        Socket["Daemon#listen_loop\nJSON-RPC 2.0 dispatch"]
+        CacheCheck{"File cached &\nmtime fresh?"}
+        CacheStorage["LRUCache\n(1000 entries)"]
+        ApplyOverrides["apply_cli_overrides\n(reset on nil)"]
+    end
+
+    ViaServer --> Socket
+    Socket --> ApplyOverrides
+    ApplyOverrides --> CacheCheck
+    CacheCheck -->|Hit| Socket
+    CacheCheck -->|Miss| Parse
+    Direct --> Parse
+    Parse["Parsing.parse_buffer\nParser gem / Prism"]
     Parse --> AST["AST + Comments"]
     AST --> Collect["Collector.process\n· Find methods\n· Track visibility\n· Find attr_*"]
     AST --> CollectPlugins["CollectorPlugin#collect\n· Custom AST walks\n· Non-standard constructs"]
@@ -317,7 +352,11 @@ flowchart LR
     Strategy -->|Aggressive| Replace["Replace entirely"]
     Merge --> Rewritten["Rewriter#process\n-> rewritten source"]
     Replace --> Rewritten
-    Rewritten --> Output["Modified .rb file\n/ STDOUT"]
+    Rewritten --> Result["Result / response"]
+    Rewritten --> CacheStorage
+    CacheStorage --> Socket
+    Result -->|Direct mode| Output["Modified .rb file / STDOUT"]
+    Result -->|Server mode| Socket
 ```
 
 ## CLI
@@ -330,6 +369,7 @@ docscribe sigs [options] [files...]
 docscribe rbs [options] [files...]
 docscribe update_types [directory]
 docscribe check_for_comments [paths...]
+docscribe server [start|status|stop] [options]
 ```
 
 Docscribe has three main ways to run:
@@ -375,6 +415,10 @@ If you pass no files and don't use `--stdin`, Docscribe processes the current di
 
 - `--explain`  
   Show detailed reasons for each file (default; no-op for compatibility).
+
+- `--server`  
+  Run via a persistent daemon (Unix socket). Speeds up repeated invocations
+  by keeping the Ruby runtime loaded and caching results.
 
 - `-k`, `--keep-descriptions`  
   Preserve existing documentation text when rebuilding doc blocks in aggressive mode.
@@ -598,6 +642,78 @@ Exit code `0` if no placeholders found, `1` if any are detected.
 **Flags:**
 
 - `-h`, `--help` — show help.
+
+### `docscribe server` — persistent daemon mode
+
+> [!NOTE]
+> Server mode requires **Ruby 3.1+** (`Process.fork` for background daemon).
+
+`docscribe server` starts a background daemon that keeps the Ruby runtime loaded and caches parsed ASTs across
+invocations. Subsequent `docscribe` calls with `--server` communicate with the daemon over a Unix socket instead of
+reloading the entire toolchain.
+
+```shell
+# Start the daemon (auto-detached in background)
+docscribe server start
+
+# Check if the daemon is running
+docscribe server status
+
+# Stop the daemon
+docscribe server stop
+
+# Use the daemon for file checks (much faster on repeated calls)
+docscribe --server lib
+docscribe -a --server lib
+```
+
+**How it works:**
+
+1. `docscribe server start` forks a background process that listens on a Unix socket in the system temp directory.
+2. The socket path is derived from the project root, `Gemfile.lock` mtime, and `rbs_collection.lock.yaml` mtime — so any
+   environment change spawns a fresh daemon automatically.
+3. Client requests (`docscribe --server`) send JSON-RPC 2.0 messages over the socket: `check` (inspect), `fix` (apply
+   changes), and `shutdown`.
+4. The daemon holds a reusable `Docscribe::Config` instance and an LRU file cache (bounded at 1000 entries), so repeated
+   checks on the same files are nearly instant.
+5. After 5 minutes of inactivity the daemon shuts down automatically.
+
+**Thin client (`docscribe-client`):**
+
+For IDE plugins and CI systems that need minimal startup overhead, a standalone thin client is available as
+`exe/docscribe-client`. It connects to the daemon via the same Unix socket protocol without loading the full docscribe
+gem:
+
+```shell
+# Check a file via the daemon
+docscribe-client check lib/user.rb
+
+# Apply fixes via the daemon
+docscribe-client fix lib/user.rb
+
+# Stop the daemon
+docscribe-client shutdown
+```
+
+The thin client is used automatically by
+the [VS Code](https://marketplace.visualstudio.com/items?itemName=unurgunite.docscribe-vscode)
+and [RubyMine](https://plugins.jetbrains.com/plugin/32349-docscribe) plugins when the daemon is running.
+
+**Environment invalidation:**
+
+The daemon's socket path includes a hash of:
+
+- `Gemfile.lock` mtime — gem changes that may affect RBS signatures.
+- `rbs_collection.lock.yaml` mtime — RBS collection signature updates.
+
+If any of these files change, the next `docscribe --server` call will start a new daemon automatically. The old daemon
+is left to idle-timeout on its own.
+
+**CLI override handling:**
+
+When CLI overrides (`-C`, `--include`, `--exclude`, etc.) change between requests, the daemon resets its effective
+configuration, clears the file cache, and applies the new overrides before processing. If no overrides are passed, the
+cached state from the initial load is used, preserving performance.
 
 ## Update strategies
 
@@ -1757,7 +1873,6 @@ yard doc -o docs
 - Overload-aware signature selection;
 - Manual `@!attribute` merge policy;
 - Richer inference for common APIs;
-- Editor integration (LSP, VS Code extension);
 - Documentation coverage report — percentage of documented methods, params, returns;
 - Pre-commit hook auto-install (`docscribe init --pre-commit`);
 - Parallel processing for large codebases.
@@ -1784,6 +1899,10 @@ Docscribe provides IDE plugins for a better development experience:
 
 > [!NOTE]
 > Both plugins require **docscribe >= 1.5.0**.
+>
+> For optimal performance, both plugins use the `docscribe-client` thin client
+> to communicate with the docscribe daemon (see [server mode](#docscribe-server--persistent-daemon-mode)).
+> Start the daemon with `docscribe server start` for near-instant diagnostics.
 
 ## Contributing
 

--- a/examples/plugins/tag_plugin/api_tag/spec/plugin_spec.rb
+++ b/examples/plugins/tag_plugin/api_tag/spec/plugin_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DocscribePlugins::ApiTagPlugin do
   after  { Docscribe::Plugin::Registry.clear! }
 
   def rewrite(code, strategy: :safe)
-    conf = Docscribe::Config.new({})
+    conf = Docscribe::Config.new
     inline(code, strategy: strategy, config: conf)
   end
 

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -6,8 +6,13 @@ require 'socket'
 require 'json'
 require 'securerandom'
 require 'digest/md5'
+require 'tmpdir'
 
-SOCKET_DIR = '/tmp'
+SOCKET_DIR = begin
+  tmp = Dir.tmpdir || '/tmp'
+  sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize
+  tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
+end
 ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
 def socket_path(config_path = nil)
@@ -64,6 +69,7 @@ OptionParser.new do |opts|
   end
   opts.on('--shutdown', 'Shutdown the server') { mode = :shutdown }
   opts.on('--status', 'Show server status') { mode = :status }
+  opts.on('--ping', 'Ping the server') { mode = :ping }
 end.parse!
 
 sock = socket_path(config_path)
@@ -78,6 +84,9 @@ when :fix
 when :shutdown
   result = send_request(sock, 'shutdown')
   puts JSON.generate(result || { error: 'Connection failed' })
+when :ping
+  result = send_request(sock, 'ping')
+  puts JSON.generate(result || { error: 'Connection failed' })
 when :status
   alive = begin
     File.exist?(sock) &&
@@ -87,6 +96,6 @@ when :status
   end
   puts JSON.generate(alive ? { status: 'running', socket: sock } : { status: 'not_running' })
 else
-  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status"
+  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status | --ping"
   exit 1
 end

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -10,16 +10,20 @@ require 'tmpdir'
 
 SOCKET_DIR = begin
   tmp = Dir.tmpdir || '/tmp'
-  sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize
+  sock_overhead = "/docscribe-#{'a' * 32}.sock".bytesize
   tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
 end
 ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
 def socket_path(config_path = nil)
-  hash = Digest::MD5.hexdigest(Dir.pwd)
-  env_seed = env_hash
-  suffix = config_path ? "-#{config_hash(config_path)}" : ''
-  "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+  seed = +Dir.pwd
+  seed << ":#{env_hash}"
+  if config_path
+    resolved = File.expand_path(config_path)
+    mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+    seed << ":#{resolved}:#{mtime}"
+  end
+  "#{SOCKET_DIR}/docscribe-#{Digest::MD5.hexdigest(seed)}.sock"
 end
 
 def env_hash

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -8,17 +8,27 @@ require 'securerandom'
 require 'digest/md5'
 
 SOCKET_DIR = '/tmp'
+ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
 def socket_path(config_path = nil)
   hash = Digest::MD5.hexdigest(Dir.pwd)
-  if config_path
-    resolved = File.expand_path(config_path)
-    mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
-    cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
-    "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
-  else
-    "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+  env_seed = env_hash
+  suffix = config_path ? "-#{config_hash(config_path)}" : ''
+  "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+end
+
+def env_hash
+  parts = ENV_FILES.map do |file|
+    path = File.join(Dir.pwd, file)
+    File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
   end
+  Digest::MD5.hexdigest(parts.join(':'))
+end
+
+def config_hash(config_path)
+  resolved = File.expand_path(config_path)
+  mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+  Digest::MD5.hexdigest("#{resolved}:#{mtime}")
 end
 
 def send_request(sock, method, params = {})

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require 'socket'
+require 'json'
+require 'securerandom'
+require 'digest/md5'
+
+SOCKET_DIR = '/tmp'
+
+def socket_path(config_path = nil)
+  hash = Digest::MD5.hexdigest(Dir.pwd)
+  if config_path
+    resolved = File.expand_path(config_path)
+    mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+    cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
+    "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
+  else
+    "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+  end
+end
+
+def send_request(sock, method, params = {})
+  socket = UNIXSocket.new(sock)
+  req = build_request(method, params)
+  socket.write("#{JSON.generate(req)}\n")
+  socket.close_write
+  line = socket.gets
+  line ? JSON.parse(line) : nil
+rescue Errno::ECONNREFUSED, Errno::ENOENT
+  nil
+ensure
+  socket&.close
+end
+
+def build_request(method, params = {})
+  { jsonrpc: '2.0', id: SecureRandom.uuid, method: method, params: params }
+end
+
+config_path = nil
+mode = nil
+file = nil
+
+OptionParser.new do |opts|
+  opts.on('-C', '--config <path>', 'Config file path') { |v| config_path = v }
+  opts.on('--check <file>', 'Check a file') do |v|
+    mode = :check
+    file = v
+  end
+  opts.on('--fix <file>', 'Fix a file') do |v|
+    mode = :fix
+    file = v
+  end
+  opts.on('--shutdown', 'Shutdown the server') { mode = :shutdown }
+  opts.on('--status', 'Show server status') { mode = :status }
+end.parse!
+
+sock = socket_path(config_path)
+
+case mode
+when :check
+  result = send_request(sock, 'check', file: file, strategy: :safe)
+  puts JSON.generate(result || { error: 'Connection failed' })
+when :fix
+  result = send_request(sock, 'fix', file: file, strategy: :safe)
+  puts JSON.generate(result || { error: 'Connection failed' })
+when :shutdown
+  result = send_request(sock, 'shutdown')
+  puts JSON.generate(result || { error: 'Connection failed' })
+when :status
+  alive = begin
+    File.exist?(sock) &&
+      UNIXSocket.new(sock).close && true
+  rescue StandardError
+    false
+  end
+  puts JSON.generate(alive ? { status: 'running', socket: sock } : { status: 'not_running' })
+else
+  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status"
+  exit 1
+end

--- a/lib/docscribe/cli.rb
+++ b/lib/docscribe/cli.rb
@@ -8,6 +8,7 @@ require 'docscribe/cli/sigs'
 require 'docscribe/cli/rbs_gen'
 require 'docscribe/cli/update_types'
 require 'docscribe/cli/check_for_comments'
+require 'docscribe/cli/server'
 
 module Docscribe
   # CLI entry point and command dispatch.
@@ -30,6 +31,16 @@ module Docscribe
         Docscribe::CLI::Run.run(options: options, argv: argv)
       end
 
+      COMMANDS = {
+        'init' => Docscribe::CLI::Init,
+        'generate' => Docscribe::CLI::Generate,
+        'sigs' => Docscribe::CLI::Sigs,
+        'rbs' => Docscribe::CLI::RbsGen,
+        'update_types' => Docscribe::CLI::UpdateTypes,
+        'check_for_comments' => Docscribe::CLI::CheckForComments,
+        'server' => Docscribe::CLI::ServerCmd
+      }.freeze
+
       private
 
       # Subcommand
@@ -38,7 +49,7 @@ module Docscribe
       # @param [String?] cmd potential subcommand name
       # @return [Boolean]
       def subcommand?(cmd)
-        %w[init generate sigs rbs update_types check_for_comments].include?(cmd)
+        COMMANDS.key?(cmd)
       end
 
       # Dispatch subcommand
@@ -48,15 +59,8 @@ module Docscribe
       # @return [Integer]
       def dispatch_subcommand(argv)
         cmd = argv.shift
-        case cmd
-        when 'init' then Docscribe::CLI::Init.run(argv)
-        when 'generate' then Docscribe::CLI::Generate.run(argv)
-        when 'sigs' then Docscribe::CLI::Sigs.run(argv)
-        when 'rbs' then Docscribe::CLI::RbsGen.run(argv)
-        when 'update_types' then Docscribe::CLI::UpdateTypes.run(argv)
-        when 'check_for_comments' then Docscribe::CLI::CheckForComments.run(argv)
-        else 0
-        end
+        mod = COMMANDS[cmd]
+        mod ? mod.run(argv) : 0
       end
     end
   end

--- a/lib/docscribe/cli.rb
+++ b/lib/docscribe/cli.rb
@@ -1,28 +1,14 @@
 # frozen_string_literal: true
 
-require 'docscribe/cli/init'
-require 'docscribe/cli/generate'
 require 'docscribe/cli/options'
 require 'docscribe/cli/run'
-require 'docscribe/cli/sigs'
-require 'docscribe/cli/rbs_gen'
-require 'docscribe/cli/update_types'
-require 'docscribe/cli/check_for_comments'
-require 'docscribe/cli/server'
 
 module Docscribe
   # CLI entry point and command dispatch.
   module CLI
     class << self
-      # Main CLI entry point.
-      #
-      # Dispatches:
-      # - `docscribe init ...`     to the config-template generator
-      # - `docscribe generate ...` to the plugin skeleton generator
-      # - all other commands to the main option parser and runner
-      #
-      # @param [Array<String>] argv raw command-line arguments
-      # @return [Integer] process exit code
+      # @param [Array<String>] argv
+      # @return [Integer]
       def run(argv)
         argv = argv.dup
         return dispatch_subcommand(argv) if subcommand?(argv.first)
@@ -32,35 +18,34 @@ module Docscribe
       end
 
       COMMANDS = {
-        'init' => Docscribe::CLI::Init,
-        'generate' => Docscribe::CLI::Generate,
-        'sigs' => Docscribe::CLI::Sigs,
-        'rbs' => Docscribe::CLI::RbsGen,
-        'update_types' => Docscribe::CLI::UpdateTypes,
-        'check_for_comments' => Docscribe::CLI::CheckForComments,
-        'server' => Docscribe::CLI::ServerCmd
+        'init' => :Init,
+        'generate' => :Generate,
+        'sigs' => :Sigs,
+        'rbs' => :RbsGen,
+        'update_types' => :UpdateTypes,
+        'check_for_comments' => :CheckForComments,
+        'server' => :ServerCmd
       }.freeze
 
       private
 
-      # Subcommand
-      #
       # @private
-      # @param [String?] cmd potential subcommand name
+      # @param [String?] cmd
       # @return [Boolean]
       def subcommand?(cmd)
         COMMANDS.key?(cmd)
       end
 
-      # Dispatch subcommand
-      #
       # @private
-      # @param [Array<String>] argv raw command-line arguments
+      # @param [Array<String>] argv
       # @return [Integer]
       def dispatch_subcommand(argv)
         cmd = argv.shift
-        mod = COMMANDS[cmd]
-        mod ? mod.run(argv) : 0
+        const_name = COMMANDS[cmd]
+        return 0 unless const_name
+
+        require "docscribe/cli/#{cmd == 'rbs' ? 'rbs_gen' : cmd}"
+        Docscribe::CLI.const_get(const_name).run(argv)
       end
     end
   end

--- a/lib/docscribe/cli/config_builder.rb
+++ b/lib/docscribe/cli/config_builder.rb
@@ -29,7 +29,7 @@ module Docscribe
         apply_rbs_overrides(raw, options) if rbs_overrides?(options)
         apply_sorbet_overrides(raw, options) if sorbet_overrides?(options)
         apply_output_overrides(raw, options)
-        conf = Docscribe::Config.new(raw)
+        conf = Docscribe::Config.new(**raw)
         warn_missing_rbs_collection(conf, options)
         conf
       end

--- a/lib/docscribe/cli/config_builder.rb
+++ b/lib/docscribe/cli/config_builder.rb
@@ -29,7 +29,7 @@ module Docscribe
         apply_rbs_overrides(raw, options) if rbs_overrides?(options)
         apply_sorbet_overrides(raw, options) if sorbet_overrides?(options)
         apply_output_overrides(raw, options)
-        conf = Docscribe::Config.new(**raw)
+        conf = Docscribe::Config.new(config_path: base.config_path, **raw)
         warn_missing_rbs_collection(conf, options)
         conf
       end

--- a/lib/docscribe/cli/generate.rb
+++ b/lib/docscribe/cli/generate.rb
@@ -12,6 +12,16 @@ module Docscribe
     #   docscribe generate tag MyPlugin --output lib/docscribe_plugins
     #   docscribe generate tag MyPlugin --stdout
     module Generate
+      BANNER = <<~TEXT
+        Usage: docscribe generate <type> <PluginName> [options]
+
+        Types:
+          tag         Generate a TagPlugin skeleton
+          collector   Generate a CollectorPlugin skeleton
+
+        Options:
+      TEXT
+
       PLUGIN_TYPES = %w[tag collector].freeze
 
       NEXT_STEPS_TEMPLATE = <<~TEXT
@@ -275,27 +285,11 @@ module Docscribe
         # @return [OptionParser]
         def build_option_parser(opts)
           OptionParser.new do |opt|
-            opt.banner = parser_banner
+            opt.banner = BANNER
             register_output_option(opt, opts)
             register_stdout_option(opt, opts)
             register_help_option(opt, opts)
           end
-        end
-
-        # Return the usage banner for the generate subcommand parser.
-        #
-        # @private
-        # @return [String]
-        def parser_banner
-          <<~TEXT
-            Usage: docscribe generate <type> <PluginName> [options]
-
-            Types:
-              tag         Generate a TagPlugin skeleton
-              collector   Generate a CollectorPlugin skeleton
-
-            Options:
-          TEXT
         end
 
         # Register the --output option on the OptionParser.

--- a/lib/docscribe/cli/options.rb
+++ b/lib/docscribe/cli/options.rb
@@ -26,7 +26,8 @@ module Docscribe
         rbs_collection: false,
         keep_descriptions: false,
         no_boilerplate: false,
-        progress: false
+        progress: false,
+        server: false
       }.freeze
 
       module_function
@@ -52,7 +53,8 @@ module Docscribe
 
         Input / config:
                 --stdin                    Read code from STDIN and print rewritten output
-            -C, --config PATH              Path to config YAML (default: docscribe.yml)
+            -C,                 --config PATH              Path to config YAML (default: docscribe.yml)
+                --server                   Use background server for faster repeated runs
 
         Type information:
                 --rbs                      Use RBS signatures for @param/@return when available
@@ -146,6 +148,7 @@ module Docscribe
       def define_input_options(opts, options)
         define_stdin_option(opts, options)
         define_config_option(opts, options)
+        define_server_option(opts, options)
       end
 
       # Define stdin option
@@ -169,6 +172,18 @@ module Docscribe
       def define_config_option(opts, options)
         opts.on('-C', '--config PATH', 'Path to config YAML (default: docscribe.yml)') do |v|
           options[:config] = v
+        end
+      end
+
+      # Define server option
+      #
+      # @note module_function: defines #define_server_option (visibility: private)
+      # @param [OptionParser] opts the option parser to configure
+      # @param [Hash<Symbol, Object>] options mutable parsed options hash
+      # @return [void]
+      def define_server_option(opts, options)
+        opts.on('--server', 'Use background server for faster repeated runs') do
+          options[:server] = true
         end
       end
 

--- a/lib/docscribe/cli/rbs_gen.rb
+++ b/lib/docscribe/cli/rbs_gen.rb
@@ -162,7 +162,7 @@ module Docscribe
         # @param [Hash<Symbol, Object>] options
         # @raise [Parser::SyntaxError]
         # @raise [StandardError]
-        # @return [Boolean] if StandardError
+        # @return [Boolean]
         # @return [Boolean] if Parser::SyntaxError
         # @return [Boolean] if StandardError
         def generate_for_file(path, options)

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -129,7 +129,7 @@ module Docscribe
         # @param [Docscribe::CLI::Formatters::opts] options parsed CLI options
         # @param [Docscribe::Config] conf effective config
         # @raise [StandardError]
-        # @return [Integer] if StandardError
+        # @return [Integer]
         # @return [Integer] if StandardError
         def run_stdin(options:, conf:)
           puts stdin_rewrite_result(options, conf)[:output]
@@ -514,7 +514,7 @@ module Docscribe
         # @param [String] path file path to display
         # @param [Pathname] pwd current working directory
         # @raise [StandardError]
-        # @return [String] if StandardError
+        # @return [String]
         # @return [Object] if StandardError
         def display_path_for(path, pwd:)
           abs = Pathname.new(path).expand_path
@@ -536,7 +536,7 @@ module Docscribe
         # @param [Docscribe::CLI::Formatters::opts] options CLI options
         # @param [Docscribe::CLI::Formatters::state] state shared processing state
         # @raise [StandardError]
-        # @return [String, nil] if StandardError
+        # @return [String, nil]
         # @return [nil] if StandardError
         def read_source_for_path(path, display_path:, options:, state:)
           File.read(path)
@@ -555,7 +555,7 @@ module Docscribe
         # @param [String] src source code
         # @param [Hash<Symbol, Object>] ctx context hash with :conf, :display_path, :options, :state keys
         # @raise [StandardError]
-        # @return [Hash<Symbol, Object>, nil] if StandardError
+        # @return [Hash<Symbol, Object>, nil]
         # @return [nil] if StandardError
         def rewrite_result_for_path(path, src:, ctx:)
           conf = ctx[:conf]
@@ -677,7 +677,7 @@ module Docscribe
         # @param [Array<Docscribe::CLI::Formatters::change>] file_changes structured change records
         # @param [Object] ctx context hash with :display_path, :options, :state keys
         # @raise [StandardError]
-        # @return [void] if StandardError
+        # @return [void]
         # @return [Object] if StandardError
         def handle_write_result(path, src:, out:, file_changes:, **ctx)
           return log_check_verdict('OK', ctx[:display_path], ctx[:options]) if out == src

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -176,32 +176,7 @@ module Docscribe
         # @param [String?] config_path
         # @return [void]
         def ensure_server_running!(config_path: nil)
-          return if Docscribe::Server.running?(config_path)
-
-          warn 'Docscribe: starting server...'
-          pid = fork do
-            daemon = Docscribe::Server::Daemon.new(config_path: config_path)
-            daemon.start
-          end
-          Process.detach(pid)
-          wait_for_server(config_path: config_path)
-        end
-
-        # Wait for the server to become ready.
-        #
-        # @param [Integer] timeout max seconds to wait
-        # @param [String?] config_path
-        # @raise [StandardError]
-        # @return [void]
-        def wait_for_server(timeout: 5, config_path: nil)
-          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-          loop do
-            return if Docscribe::Server.running?(config_path)
-
-            raise 'Docscribe: server failed to start' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
-
-            sleep 0.1
-          end
+          Docscribe::Server.ensure_running!(config_path: config_path)
         end
 
         # Process a single file via the server client.

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -50,6 +50,8 @@ module Docscribe
         # @param [Array<String>] argv remaining path arguments
         # @return [Integer] process exit code
         def run(options:, argv:)
+          return run_via_server(options: options, argv: argv) if options[:server]
+
           conf = build_config(options)
 
           return run_stdin(options: options, conf: conf) if options[:mode] == :stdin
@@ -58,6 +60,48 @@ module Docscribe
           return no_files_found unless paths.any?
 
           run_files(options: options, conf: conf, paths: paths)
+        end
+
+        # Run via the background server daemon.
+        #
+        # Each file is processed by the server, which keeps the Ruby runtime loaded
+        # between requests.
+        #
+        # @param [Docscribe::CLI::Formatters::opts] options parsed CLI options
+        # @param [Array<String>] argv remaining path arguments
+        # @raise [RuntimeError]
+        # @return [Integer] if RuntimeError
+        # @return [Integer] if RuntimeError
+        def run_via_server(options:, argv:)
+          require 'docscribe/server'
+          conf = build_config(options)
+          ensure_server_running!(config_path: conf.config_path)
+          client = Docscribe::Server::Client.new(config_path: conf.config_path)
+          paths = filtered_paths(argv, conf)
+          return no_files_found unless paths.any?
+
+          run_files_via_server(client, paths, options)
+        rescue RuntimeError => e
+          warn e.message
+          1
+        end
+
+        # Run files through the server client with progress tracking.
+        #
+        # @param [Docscribe::Server::Client] client server client
+        # @param [Array<String>] paths file paths to process
+        # @param [Docscribe::CLI::Formatters::opts] options CLI options
+        # @return [Integer] exit code
+        def run_files_via_server(client, paths, options)
+          $stdout.sync = true
+          state = initial_run_state
+          state[:total] = paths.size
+          pwd = Pathname.pwd
+          paths.each do |path|
+            process_one_file_via_server(client, path, options: options, pwd: pwd, state: state)
+          end
+          finalize_run(options, state)
+          run_exit_code(options, state)
         end
 
         # Load and build the effective config from CLI options.
@@ -125,6 +169,183 @@ module Docscribe
         def no_files_found
           warn 'No files found. Pass files or directories (e.g. `docscribe lib`).'
           2
+        end
+
+        # Ensure the server daemon is running, auto-starting if necessary.
+        #
+        # @param [String?] config_path
+        # @return [void]
+        def ensure_server_running!(config_path: nil)
+          return if Docscribe::Server.running?(config_path)
+
+          warn 'Docscribe: starting server...'
+          pid = fork do
+            daemon = Docscribe::Server::Daemon.new(config_path: config_path)
+            daemon.start
+          end
+          Process.detach(pid)
+          wait_for_server(config_path: config_path)
+        end
+
+        # Wait for the server to become ready.
+        #
+        # @param [Integer] timeout max seconds to wait
+        # @param [String?] config_path
+        # @raise [StandardError]
+        # @return [void]
+        def wait_for_server(timeout: 5, config_path: nil)
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+          loop do
+            return if Docscribe::Server.running?(config_path)
+
+            raise 'Docscribe: server failed to start' if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+            sleep 0.1
+          end
+        end
+
+        # Process a single file via the server client.
+        #
+        # @param [Docscribe::Server::Client] client server client
+        # @param [String] path file path
+        # @param [Docscribe::CLI::Formatters::opts] options CLI options
+        # @param [Pathname] pwd current working directory
+        # @param [Docscribe::CLI::Formatters::state] state shared processing state
+        # @return [void]
+        def process_one_file_via_server(client, path, options:, pwd:, state:)
+          display_path = display_path_for(path, pwd: pwd)
+          report_progress(state, options, display_path)
+          response = send_server_request(client, path, options)
+          return server_error(path, state, 'Server unreachable') unless response
+          return server_error(path, state, response['error']['message']) if response['error']
+
+          result = response['result']
+          file_changes = (result['changes'] || []).map { |c| symbolize_change(c) }
+          dispatch_server_result(result, file_changes, path,
+                                 display_path: display_path, options: options, state: state)
+        end
+
+        # Send a request to the server for a file.
+        #
+        # @param [Docscribe::Server::Client] client server client
+        # @param [String] path file path
+        # @param [Docscribe::CLI::Formatters::opts] options CLI options
+        # @return [Hash<String, Object>, nil] server response
+        def send_server_request(client, path, options)
+          method_name = options[:mode] == :write ? 'fix' : 'check'
+          strategy = options[:strategy].to_s
+          client.send(method_name, file: path, strategy: strategy)
+        end
+
+        # Record a server error in the shared state and print an indicator.
+        #
+        # @param [String] path file path
+        # @param [Docscribe::CLI::Formatters::state] state shared processing state
+        # @param [String] message error message
+        # @return [void]
+        def server_error(path, state, message)
+          state[:had_errors] = true
+          state[:error_paths] << path
+          state[:error_messages][path] = message
+          $stderr.print('E')
+        end
+
+        # Dispatch the server result to check or write handler.
+        #
+        # @param [Hash<String, Object>] result server result with :changed and :changes keys
+        # @param [Array<Docscribe::CLI::Formatters::change>] file_changes change records
+        # @param [String] path file path
+        # @param [Object] ctx context hash with :display_path, :options, :state keys
+        # @return [void]
+        def dispatch_server_result(result, file_changes, path, **ctx)
+          if ctx[:options][:mode] == :check
+            handle_via_server_check(path, file_changes: file_changes,
+                                          display_path: ctx[:display_path],
+                                          options: ctx[:options], state: ctx[:state])
+          else
+            write_server_result(result, file_changes, display_path: ctx[:display_path],
+                                                      options: ctx[:options], state: ctx[:state])
+          end
+        end
+
+        # Handle a server write-mode result.
+        #
+        # @param [Hash<String, Object>] result server result with :changed key
+        # @param [Array<Docscribe::CLI::Formatters::change>] file_changes change records
+        # @param [String] display_path path shown in CLI output
+        # @param [Docscribe::CLI::Formatters::opts] options CLI options
+        # @param [Docscribe::CLI::Formatters::state] state shared processing state
+        # @return [void]
+        def write_server_result(result, file_changes, display_path:, options:, state:)
+          if result['changed']
+            state[:corrected] += 1
+            state[:corrected_paths] << display_path
+            state[:corrected_changes][display_path] = file_changes
+            log_check_verdict('CHANGED', display_path, options)
+          else
+            log_check_verdict('OK', display_path, options)
+          end
+        end
+
+        # Handle a check result from the server.
+        #
+        # @param [String] path file path
+        # @param [Array<Docscribe::CLI::Formatters::change>] file_changes change records from server
+        # @param [String] display_path path shown in CLI output
+        # @param [Docscribe::CLI::Formatters::opts] options CLI options
+        # @param [Docscribe::CLI::Formatters::state] state shared processing state
+        # @return [void]
+        def handle_via_server_check(path, file_changes:, display_path:, options:, state:)
+          if file_changes.empty?
+            state[:checked_ok] += 1
+            return log_check_verdict('OK', display_path, options)
+          end
+
+          report_check_failure(display_path, file_changes, options)
+          update_check_failure_state(path, file_changes, state)
+        end
+
+        # Report a check failure with verbose or compact output.
+        #
+        # @param [String] display_path path shown in CLI output
+        # @param [Array<Docscribe::CLI::Formatters::change>] file_changes change records from server
+        # @param [Docscribe::CLI::Formatters::opts] options CLI options
+        # @return [void]
+        def report_check_failure(display_path, file_changes, options)
+          if options[:verbose]
+            warn("FAIL #{display_path}")
+            print_check_explanations(file_changes)
+          else
+            $stderr.print('F')
+          end
+        end
+
+        # Update shared state after a check failure.
+        #
+        # @param [String] path file path
+        # @param [Array<Docscribe::CLI::Formatters::change>] file_changes change records from server
+        # @param [Docscribe::CLI::Formatters::state] state shared processing state
+        # @return [void]
+        def update_check_failure_state(path, file_changes, state)
+          state[:checked_fail] += 1
+          state[:changed] = true
+          state[:fail_paths] << path
+          state[:fail_changes][path] = file_changes
+        end
+
+        # Convert server response change (string keys) to formatter-compatible
+        # change (symbol keys).
+        #
+        # @param [Hash<String, Object>] change change record from server
+        # @return [Docscribe::CLI::Formatters::change]
+        def symbolize_change(change)
+          {
+            type: change['type'].to_sym,
+            file: change['file'],
+            line: change['line'],
+            method: change['method'],
+            message: change['message']
+          }
         end
 
         # Expand CLI path arguments into a sorted list of Ruby files.

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -4,7 +4,6 @@ require 'pathname'
 
 require 'docscribe/cli/config_builder'
 require 'docscribe/cli/formatters'
-require 'docscribe/inline_rewriter'
 
 module Docscribe
   module CLI
@@ -35,6 +34,14 @@ module Docscribe
           total: 0,
           processed: 0
         }.freeze
+
+        CLI_OVERRIDE_KEYS = %i[
+          keep_descriptions no_boilerplate
+          include exclude include_file exclude_file
+          rbs rbs_collection sig_dirs
+          sorbet rbi_dirs
+        ].freeze
+
         # Run Docscribe for files or STDIN using the selected mode and strategy.
         #
         # Modes:
@@ -52,6 +59,7 @@ module Docscribe
         def run(options:, argv:)
           return run_via_server(options: options, argv: argv) if options[:server]
 
+          require 'docscribe/inline_rewriter'
           conf = build_config(options)
 
           return run_stdin(options: options, conf: conf) if options[:mode] == :stdin
@@ -62,19 +70,14 @@ module Docscribe
           run_files(options: options, conf: conf, paths: paths)
         end
 
-        # Run via the background server daemon.
-        #
-        # Each file is processed by the server, which keeps the Ruby runtime loaded
-        # between requests.
-        #
-        # @param [Docscribe::CLI::Formatters::opts] options parsed CLI options
-        # @param [Array<String>] argv remaining path arguments
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @param [Array<String>] argv
         # @raise [RuntimeError]
-        # @return [Integer] if RuntimeError
+        # @return [Integer]
         # @return [Integer] if RuntimeError
         def run_via_server(options:, argv:)
           require 'docscribe/server'
-          conf = build_config(options)
+          conf = build_light_config(options)
           ensure_server_running!(config_path: conf.config_path)
           client = Docscribe::Server::Client.new(config_path: conf.config_path)
           paths = filtered_paths(argv, conf)
@@ -104,15 +107,20 @@ module Docscribe
           run_exit_code(options, state)
         end
 
-        # Load and build the effective config from CLI options.
-        #
-        # @param [Docscribe::CLI::Formatters::opts] options parsed CLI options
-        # @return [Docscribe::Config] effective config with plugins loaded
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Docscribe::Config]
         def build_config(options)
           conf = Docscribe::Config.load(options[:config])
           conf = Docscribe::CLI::ConfigBuilder.build(conf, options)
           conf.load_plugins!
           conf
+        end
+
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Docscribe::Config]
+        def build_light_config(options)
+          conf = Docscribe::Config.load(options[:config])
+          Docscribe::CLI::ConfigBuilder.build(conf, options)
         end
 
         # Rewrite code from STDIN using the selected strategy and print the
@@ -200,16 +208,19 @@ module Docscribe
                                  display_path: display_path, options: options, state: state)
         end
 
-        # Send a request to the server for a file.
-        #
-        # @param [Docscribe::Server::Client] client server client
-        # @param [String] path file path
-        # @param [Docscribe::CLI::Formatters::opts] options CLI options
-        # @return [Hash<String, Object>, nil] server response
+        # @param [Docscribe::Server::Client] client
+        # @param [String] path
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Hash<String, Object>, nil]
         def send_server_request(client, path, options)
-          method_name = options[:mode] == :write ? 'fix' : 'check'
+          method_name = options[:mode] == :write ? :fix : :check
           strategy = options[:strategy].to_s
-          client.send(method_name, file: path, strategy: strategy)
+          cli_overrides = extract_cli_overrides(options)
+          if cli_overrides.empty?
+            client.send(method_name, file: path, strategy: strategy)
+          else
+            client.send(method_name, file: path, strategy: strategy, cli_overrides: cli_overrides)
+          end
         end
 
         # Record a server error in the shared state and print an indicator.
@@ -384,6 +395,20 @@ module Docscribe
           finalize_run(options, state)
 
           run_exit_code(options, state)
+        end
+
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Hash<String, Object>]
+        def extract_cli_overrides(options)
+          overrides = options.slice(*CLI_OVERRIDE_KEYS)
+          acc = {} #: Hash[String, untyped]
+          overrides.each do |k, v|
+            next if v.nil? || v == false
+            next if v.is_a?(Array) && v.empty?
+
+            acc[k.to_s] = v
+          end
+          acc
         end
 
         private

--- a/lib/docscribe/cli/server.rb
+++ b/lib/docscribe/cli/server.rb
@@ -95,16 +95,31 @@ module Docscribe
         # @return [Integer] exit code
         def show_status(config_path = nil)
           require 'docscribe/server'
+          return warn('Docscribe server is not running') || 0 unless Docscribe::Server.running?(config_path)
 
-          unless Docscribe::Server.running?(config_path)
-            warn 'Docscribe server is not running'
-            return 0
-          end
+          info = Docscribe::Server::Client.new(config_path: config_path).ping
+          info ? show_status_from_ping(info) : show_status_fallback(config_path)
+          0
+        end
 
+        # @private
+        # @param [Hash<String, Object>] info ping response hash
+        # @return [void]
+        def show_status_from_ping(info)
+          pid = info.dig('result', 'pid')
+          version = info.dig('result', 'version')
+          uptime = info.dig('result', 'uptime')
+          sock = info.dig('result', 'socket_path')
+          warn "Docscribe server v#{version} is running (pid #{pid}, socket #{sock}, uptime #{uptime}s)"
+        end
+
+        # @private
+        # @param [String?] config_path
+        # @return [void]
+        def show_status_fallback(config_path)
           pid = Docscribe::Server.read_pid(config_path)
           sock = Docscribe::Server.socket_path(config_path)
           warn "Docscribe server is running (pid #{pid}, socket #{sock})"
-          0
         end
 
         # Print usage information for the server subcommand.

--- a/lib/docscribe/cli/server.rb
+++ b/lib/docscribe/cli/server.rb
@@ -1,16 +1,21 @@
 # frozen_string_literal: true
 
+require 'optparse'
+
 module Docscribe
   module CLI
     # Handle the `docscribe server` subcommand.
     module ServerCmd
       BANNER = <<~TEXT
-        Usage: docscribe server <command>
+        Usage: docscribe server <command> [options]
 
         Commands:
           start    Start the background daemon
           stop     Stop the background daemon
           status   Show daemon status
+
+        Options:
+          -C, --config <path>    Config file path (default: auto-detect)
 
         Once the server is running, use `--server` with other commands:
           docscribe --server check lib/
@@ -23,63 +28,62 @@ module Docscribe
         # @param [Array<String>] argv subcommand arguments
         # @return [Integer] exit code
         def run(argv)
-          cmd = argv.first
+          config_path, cmd = parse_args(argv)
+          return warn(BANNER) || 1 unless cmd
 
           case cmd
-          when 'start' then start_server
-          when 'stop' then stop_server
-          when 'status' then show_status
-          else
-            warn usage
-            1
+          when 'start' then start_server(config_path)
+          when 'stop' then stop_server(config_path)
+          when 'status' then show_status(config_path)
+          else warn(usage) || 1
           end
         end
 
         private
 
+        # @private
+        # @param [Array<String>] argv
+        # @return [(String?, String?)]
+        def parse_args(argv)
+          config_path = nil
+          rest = OptionParser.new do |opts|
+            opts.on('-C', '--config <path>', 'Config file path') { |v| config_path = v }
+          end.parse!(argv.dup)
+          [config_path, rest.first]
+        end
+
         # Start the background daemon process.
         #
         # @private
+        # @param [String?] config_path optional config file path
         # @return [Integer] exit code
-        def start_server
+        def start_server(config_path = nil)
           require 'docscribe/server'
-          return already_running if Docscribe::Server.running?
+          return already_running(config_path) if Docscribe::Server.running?(config_path)
 
-          fork_and_wait
-          pid = Docscribe::Server.read_pid
+          Docscribe::Server.ensure_running!(daemonize: true, config_path: config_path)
+          pid = Docscribe::Server.read_pid(config_path)
           warn "Docscribe server started (pid #{pid})"
           0
         end
 
         # @private
+        # @param [String?] config_path optional config file path
         # @return [Integer]
-        def already_running
-          pid = Docscribe::Server.read_pid
+        def already_running(config_path = nil)
+          pid = Docscribe::Server.read_pid(config_path)
           warn "Docscribe server already running (pid #{pid})"
           0
-        end
-
-        # @private
-        # @return [void]
-        def fork_and_wait
-          pid = fork do
-            $stdin.reopen(File::NULL)
-            $stdout.reopen(File::NULL)
-            $stderr.reopen(File::NULL)
-            daemon = Docscribe::Server::Daemon.new
-            daemon.start
-          end
-          Process.detach(pid)
-          wait_for_startup
         end
 
         # Stop the background daemon.
         #
         # @private
+        # @param [String?] config_path optional config file path
         # @return [Integer] exit code
-        def stop_server
+        def stop_server(config_path = nil)
           require 'docscribe/server'
-          alive = Docscribe::Server::Client.new.shutdown
+          alive = Docscribe::Server::Client.new(config_path: config_path).shutdown
           warn(alive ? 'Docscribe server stopped' : 'Docscribe server is not running')
           0
         end
@@ -87,17 +91,18 @@ module Docscribe
         # Show the server status.
         #
         # @private
+        # @param [String?] config_path optional config file path
         # @return [Integer] exit code
-        def show_status
+        def show_status(config_path = nil)
           require 'docscribe/server'
 
-          unless Docscribe::Server.running?
+          unless Docscribe::Server.running?(config_path)
             warn 'Docscribe server is not running'
             return 0
           end
 
-          pid = Docscribe::Server.read_pid
-          sock = Docscribe::Server.socket_path
+          pid = Docscribe::Server.read_pid(config_path)
+          sock = Docscribe::Server.socket_path(config_path)
           warn "Docscribe server is running (pid #{pid}, socket #{sock})"
           0
         end
@@ -108,25 +113,6 @@ module Docscribe
         # @return [String]
         def usage
           BANNER
-        end
-
-        # Wait for the server to become ready after starting.
-        #
-        # @private
-        # @param [Integer] timeout max seconds to wait
-        # @return [void]
-        def wait_for_startup(timeout: 5)
-          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-          loop do
-            break if Docscribe::Server.running?
-
-            if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
-              warn 'Docscribe server failed to start within timeout'
-              break
-            end
-
-            sleep 0.1
-          end
         end
       end
     end

--- a/lib/docscribe/cli/server.rb
+++ b/lib/docscribe/cli/server.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module Docscribe
+  module CLI
+    # Handle the `docscribe server` subcommand.
+    module ServerCmd
+      BANNER = <<~TEXT
+        Usage: docscribe server <command>
+
+        Commands:
+          start    Start the background daemon
+          stop     Stop the background daemon
+          status   Show daemon status
+
+        Once the server is running, use `--server` with other commands:
+          docscribe --server check lib/
+          docscribe --server --autocorrect lib/
+      TEXT
+
+      class << self
+        # Run the server subcommand.
+        #
+        # @param [Array<String>] argv subcommand arguments
+        # @return [Integer] exit code
+        def run(argv)
+          cmd = argv.first
+
+          case cmd
+          when 'start' then start_server
+          when 'stop' then stop_server
+          when 'status' then show_status
+          else
+            warn usage
+            1
+          end
+        end
+
+        private
+
+        # Start the background daemon process.
+        #
+        # @private
+        # @return [Integer] exit code
+        def start_server
+          require 'docscribe/server'
+          return already_running if Docscribe::Server.running?
+
+          fork_and_wait
+          pid = Docscribe::Server.read_pid
+          warn "Docscribe server started (pid #{pid})"
+          0
+        end
+
+        # @private
+        # @return [Integer]
+        def already_running
+          pid = Docscribe::Server.read_pid
+          warn "Docscribe server already running (pid #{pid})"
+          0
+        end
+
+        # @private
+        # @return [void]
+        def fork_and_wait
+          pid = fork do
+            $stdin.reopen(File::NULL)
+            $stdout.reopen(File::NULL)
+            $stderr.reopen(File::NULL)
+            daemon = Docscribe::Server::Daemon.new
+            daemon.start
+          end
+          Process.detach(pid)
+          wait_for_startup
+        end
+
+        # Stop the background daemon.
+        #
+        # @private
+        # @return [Integer] exit code
+        def stop_server
+          require 'docscribe/server'
+          alive = Docscribe::Server::Client.new.shutdown
+          warn(alive ? 'Docscribe server stopped' : 'Docscribe server is not running')
+          0
+        end
+
+        # Show the server status.
+        #
+        # @private
+        # @return [Integer] exit code
+        def show_status
+          require 'docscribe/server'
+
+          unless Docscribe::Server.running?
+            warn 'Docscribe server is not running'
+            return 0
+          end
+
+          pid = Docscribe::Server.read_pid
+          sock = Docscribe::Server.socket_path
+          warn "Docscribe server is running (pid #{pid}, socket #{sock})"
+          0
+        end
+
+        # Print usage information for the server subcommand.
+        #
+        # @private
+        # @return [String]
+        def usage
+          BANNER
+        end
+
+        # Wait for the server to become ready after starting.
+        #
+        # @private
+        # @param [Integer] timeout max seconds to wait
+        # @return [void]
+        def wait_for_startup(timeout: 5)
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+          loop do
+            break if Docscribe::Server.running?
+
+            if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+              warn 'Docscribe server failed to start within timeout'
+              break
+            end
+
+            sleep 0.1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/docscribe/cli/sigs.rb
+++ b/lib/docscribe/cli/sigs.rb
@@ -160,7 +160,7 @@ module Docscribe
         # @param [Array<Docscribe::CLI::Sigs::MethodDef>] methods
         # @raise [Parser::SyntaxError]
         # @raise [StandardError]
-        # @return [void] if StandardError
+        # @return [void]
         # @return [nil] if Parser::SyntaxError
         # @return [nil] if StandardError
         def extract_methods_from_file(path, methods)
@@ -281,7 +281,7 @@ module Docscribe
         # @param [Hash<Symbol, Object>] options
         # @raise [LoadError]
         # @raise [StandardError]
-        # @return [Docscribe::Types::RBS::Provider?] if StandardError
+        # @return [Docscribe::Types::RBS::Provider?]
         # @return [nil] if LoadError
         # @return [nil] if StandardError
         def build_provider(options)
@@ -298,7 +298,7 @@ module Docscribe
 
         # @private
         # @raise [StandardError]
-        # @return [Array<String>] if StandardError
+        # @return [Array<String>]
         # @return [Array] if StandardError
         def load_collection_dirs
           dir = Docscribe::Types::RBS::CollectionLoader.resolve

--- a/lib/docscribe/cli/sigs.rb
+++ b/lib/docscribe/cli/sigs.rb
@@ -161,8 +161,8 @@ module Docscribe
         # @raise [Parser::SyntaxError]
         # @raise [StandardError]
         # @return [void] if StandardError
-        # @return [Object] if Parser::SyntaxError
-        # @return [Object] if StandardError
+        # @return [nil] if Parser::SyntaxError
+        # @return [nil] if StandardError
         def extract_methods_from_file(path, methods)
           src = File.read(path)
           ast = Docscribe::Parsing.parse(src, file: path)

--- a/lib/docscribe/config.rb
+++ b/lib/docscribe/config.rb
@@ -11,14 +11,20 @@ module Docscribe
     #   @return [Hash<String, Object>]
     attr_reader :raw
 
+    # @!attribute [r] config_path
+    #   @return [String?]
+    attr_reader :config_path
+
     # Create a configuration object from a raw config hash.
     #
     # Missing keys are filled from {DEFAULT} via deep merge.
     #
+    # @param [String?] config_path optional path to the config file
     # @param [Hash<String, Object>] raw user-provided config hash
     # @return [void]
-    def initialize(raw = {})
-      @raw = deep_merge(DEFAULT, raw || {})
+    def initialize(config_path: nil, **raw)
+      @raw = deep_merge(DEFAULT, raw)
+      @config_path = config_path
     end
   end
 end

--- a/lib/docscribe/config/defaults.rb
+++ b/lib/docscribe/config/defaults.rb
@@ -70,7 +70,8 @@ module Docscribe
       'sorbet' => {
         'enabled' => false,
         'rbi_dirs' => ['sorbet/rbi', 'rbi'],
-        'collapse_generics' => false
+        'collapse_generics' => false,
+        'collapse_object_generics' => false
       },
       'keep_descriptions' => false,
       'skip_anonymous_block_params' => false,

--- a/lib/docscribe/config/filtering.rb
+++ b/lib/docscribe/config/filtering.rb
@@ -32,8 +32,8 @@ module Docscribe
     #
     # @param [String] path file path to test
     # @raise [StandardError]
+    # @return [String]
     # @return [String] if StandardError
-    # @return [Object] if StandardError
     def relative_path(path)
       Pathname.new(path).expand_path.relative_path_from(Pathname.pwd).cleanpath.to_s
     rescue StandardError

--- a/lib/docscribe/config/loader.rb
+++ b/lib/docscribe/config/loader.rb
@@ -45,7 +45,7 @@ module Docscribe
     # @param [String] yaml YAML document
     # @param [String?] filename optional filename for diagnostics
     # @raise [ArgumentError]
-    # @return [Hash<String, Object>] if ArgumentError
+    # @return [Hash<String, Object>]
     # @return [Object] if ArgumentError
     def self.safe_load_compat(yaml, filename: nil)
       pclasses = [] #: Array[String]

--- a/lib/docscribe/config/loader.rb
+++ b/lib/docscribe/config/loader.rb
@@ -14,12 +14,10 @@ module Docscribe
     # @return [Docscribe::Config]
     def self.load(path = nil)
       raw = {} #: Hash[String, untyped]
-      if path && File.file?(path)
-        raw = safe_load_file_compat(path)
-      elsif File.file?('docscribe.yml')
-        raw = safe_load_file_compat('docscribe.yml')
-      end
-      new(raw)
+      resolved = path if path && File.file?(path)
+      resolved ||= 'docscribe.yml' if File.file?('docscribe.yml')
+      raw = safe_load_file_compat(resolved) if resolved
+      new(config_path: resolved, **raw) # steep:ignore
     end
 
     # Safely load YAML from a file across Ruby/Psych versions.

--- a/lib/docscribe/config/rbs.rb
+++ b/lib/docscribe/config/rbs.rb
@@ -62,7 +62,7 @@ module Docscribe
     #
     # @private
     # @raise [LoadError]
-    # @return [Docscribe::Types::RBS::Provider, nil] if LoadError
+    # @return [Docscribe::Types::RBS::Provider, nil]
     # @return [nil] if LoadError
     def build_rbs_provider
       require 'docscribe/types/rbs/provider'
@@ -81,7 +81,7 @@ module Docscribe
     #
     # @private
     # @raise [LoadError]
-    # @return [Docscribe::Types::RBS::Provider, nil] if LoadError
+    # @return [Docscribe::Types::RBS::Provider, nil]
     # @return [nil] if LoadError
     def build_core_rbs_provider
       require 'docscribe/types/rbs/provider'

--- a/lib/docscribe/config/sorbet.rb
+++ b/lib/docscribe/config/sorbet.rb
@@ -47,7 +47,8 @@ module Docscribe
       Docscribe::Types::Sorbet::SourceProvider.new(
         source: source,
         file: file,
-        collapse_generics: sorbet_collapse_generics?
+        collapse_generics: sorbet_collapse_generics?,
+        collapse_object_generics: sorbet_collapse_object_generics?
       )
     rescue LoadError
       nil
@@ -74,10 +75,9 @@ module Docscribe
 
       @sorbet_rbi_provider ||= begin
         require 'docscribe/types/sorbet/rbi_provider'
-        Docscribe::Types::Sorbet::RBIProvider.new(
-          rbi_dirs: sorbet_rbi_dirs,
-          collapse_generics: sorbet_collapse_generics?
-        )
+        Docscribe::Types::Sorbet::RBIProvider.new(rbi_dirs: sorbet_rbi_dirs,
+                                                  collapse_generics: sorbet_collapse_generics?,
+                                                  collapse_object_generics: sorbet_collapse_object_generics?)
       rescue LoadError
         nil
       end
@@ -105,6 +105,15 @@ module Docscribe
     # @return [Boolean]
     def sorbet_collapse_generics?
       fetch_bool(%w[sorbet collapse_generics], rbs_collapse_generics?)
+    end
+
+    # Whether to collapse Object-typed generics in Sorbet types.
+    #
+    # Falls back to the RBS setting when Sorbet-specific config is not present.
+    #
+    # @return [Boolean]
+    def sorbet_collapse_object_generics?
+      fetch_bool(%w[sorbet collapse_object_generics], rbs_collapse_object_generics?)
     end
   end
 end

--- a/lib/docscribe/config/sorbet.rb
+++ b/lib/docscribe/config/sorbet.rb
@@ -40,7 +40,7 @@ module Docscribe
     # @param [String] source Ruby source being rewritten
     # @param [String] file source name for diagnostics
     # @raise [LoadError]
-    # @return [Docscribe::Types::Sorbet::SourceProvider, nil] if LoadError
+    # @return [Docscribe::Types::Sorbet::SourceProvider, nil]
     # @return [nil] if LoadError
     def sorbet_source_provider(source, file)
       require 'docscribe/types/sorbet/source_provider'

--- a/lib/docscribe/config/template.rb
+++ b/lib/docscribe/config/template.rb
@@ -98,6 +98,7 @@ module Docscribe
           enabled: false
           rbi_dirs: ["sorbet/rbi", "rbi"]
           collapse_generics: false
+          collapse_object_generics: false
 
         # Preserve existing @param/@return descriptions in aggressive mode
         keep_descriptions: false

--- a/lib/docscribe/infer.rb
+++ b/lib/docscribe/infer.rb
@@ -95,15 +95,19 @@ module Docscribe
       # @param [Boolean] nil_as_optional render nil as optional
       # @param [Docscribe::Types::RBS::Provider?] core_rbs_provider core RBS type lookup provider
       # @param [Hash<String, String>?] param_types parameter name -> type map
+      # @param [String?] container
+      # @param [Docscribe::Types::ProviderChain?] signature_provider
       # @return [Hash<Symbol, String, Array<(Array<String>, String)>>]
-      def returns_spec_from_node(node, fallback_type: FALLBACK_TYPE, nil_as_optional: true, core_rbs_provider: nil,
-                                 param_types: nil)
+      def returns_spec_from_node(node, fallback_type: FALLBACK_TYPE, nil_as_optional: true, core_rbs_provider: nil, # rubocop:disable Metrics/ParameterLists
+                                 param_types: nil, container: nil, signature_provider: nil)
         Returns.returns_spec_from_node(
           node,
           fallback_type: fallback_type,
           nil_as_optional: nil_as_optional,
           core_rbs_provider: core_rbs_provider,
-          param_types: param_types
+          param_types: param_types,
+          container: container,
+          signature_provider: signature_provider
         )
       end
 

--- a/lib/docscribe/infer/params.rb
+++ b/lib/docscribe/infer/params.rb
@@ -90,7 +90,7 @@ module Docscribe
       # @note module_function: defines #parse_expr (visibility: private)
       # @param [String?] src expression source
       # @raise [Parser::SyntaxError]
-      # @return [Parser::AST::Node, nil] if Parser::SyntaxError
+      # @return [Parser::AST::Node, nil]
       # @return [nil] if Parser::SyntaxError
       def parse_expr(src)
         return nil if src.nil? || src.strip.empty?

--- a/lib/docscribe/infer/returns.rb
+++ b/lib/docscribe/infer/returns.rb
@@ -14,7 +14,7 @@ module Docscribe
       # @note module_function: defines #infer_return_type (visibility: private)
       # @param [String?] method_source full method definition source
       # @raise [Parser::SyntaxError]
-      # @return [String] if Parser::SyntaxError
+      # @return [String]
       # @return [FALLBACK_TYPE] if Parser::SyntaxError
       def infer_return_type(method_source)
         return FALLBACK_TYPE if method_source.nil? || method_source.strip.empty?
@@ -238,7 +238,7 @@ module Docscribe
       # @return [String, nil]
       def handle_lvar_node(node, **opts)
         name = node.children[0].to_s
-        opts[:local_var_types]&.fetch(name, nil) || opts[:fallback_type]
+        lookup_lvar_type(name, opts[:local_var_types], opts[:param_types]) || opts[:fallback_type]
       end
 
       # Handle `:ivar` node for last_expr_type — look up instance variable in local_var_types.
@@ -650,6 +650,9 @@ module Docscribe
                                         opts[:param_types])
         return rbs_type if rbs_type
 
+        rbs_type = resolve_rbs_for_send_with_signature_provider(recv, meth, **opts)
+        return rbs_type if rbs_type
+
         container_rbs_return_type(meth, **opts) if recv.nil?
       end
 
@@ -666,13 +669,34 @@ module Docscribe
       # @param [Hash<String, String>, nil] param_types parameter name to type map
       # @return [String, nil] resolved type or nil if unresolvable
       def resolve_rbs_for_send(recv, meth, core_rbs_provider, local_var_types, param_types)
-        return nil unless core_rbs_provider
-
         recv_type = receiver_rbs_type_name(recv, core_rbs_provider, local_var_types, param_types)
         return nil unless recv_type
 
-        rbs = resolve_rbs_return_type(recv_type, meth, core_rbs_provider)
-        rbs unless rbs == FALLBACK_TYPE
+        if core_rbs_provider
+          rbs = resolve_rbs_return_type(recv_type, meth, core_rbs_provider)
+          return rbs unless rbs == FALLBACK_TYPE
+        end
+
+        nil
+      end
+
+      # Resolve RBS return type via signature_provider fallback.
+      #
+      # Tries project-level RBS when core_rbs_provider fails.
+      #
+      # @note module_function: defines #resolve_rbs_for_send_with_signature_provider (visibility: private)
+      # @param [Parser::AST::Node, nil] recv the receiver node
+      # @param [Symbol] meth the method name
+      # @param [Object] opts additional keyword options
+      # @return [String, nil]
+      def resolve_rbs_for_send_with_signature_provider(recv, meth, **opts)
+        return nil unless opts[:signature_provider]
+
+        recv_type = receiver_rbs_type_name(recv, opts[:core_rbs_provider], opts[:local_var_types],
+                                           opts[:param_types])
+        return nil unless recv_type
+
+        opts[:signature_provider].signature_for(container: recv_type, scope: :instance, name: meth)&.return_type
       end
 
       # Resolve return type from the current method's container via RBS.

--- a/lib/docscribe/infer/returns.rb
+++ b/lib/docscribe/infer/returns.rb
@@ -67,16 +67,19 @@ module Docscribe
       # @param [Boolean] nil_as_optional whether `nil` unions should be rendered as optional types
       # @param [Object?] core_rbs_provider core RBS type lookup provider
       # @param [Hash<String, String>?] param_types parameter name -> type map
+      # @param [String?] container
+      # @param [Docscribe::Types::ProviderChain?] signature_provider
       # @return [Object]
-      def returns_spec_from_node(node, fallback_type: FALLBACK_TYPE, nil_as_optional: true, core_rbs_provider: nil,
-                                 param_types: nil)
+      def returns_spec_from_node(node, fallback_type: FALLBACK_TYPE, nil_as_optional: true, core_rbs_provider: nil, # rubocop:disable Metrics/ParameterLists
+                                 param_types: nil, container: nil, signature_provider: nil)
         body = extract_def_body(node)
         spec = { normal: FALLBACK_TYPE, rescues: [] } #: Hash[Symbol, untyped]
         return spec unless body
 
         types = build_local_variable_types(body, core_rbs_provider: core_rbs_provider, param_types: param_types)
         populate_returns_spec(spec, body, types, fallback_type: fallback_type, nil_as_optional: nil_as_optional,
-                                                 core_rbs_provider: core_rbs_provider, param_types: param_types)
+                                                 core_rbs_provider: core_rbs_provider, param_types: param_types,
+                                                 container: container, signature_provider: signature_provider)
         spec
       end
 
@@ -608,11 +611,8 @@ module Docscribe
       def handle_block_node(node, **opts)
         send_node = node.children[0]
         if send_node&.type == :send
-          recv = send_node.children[0]
-          meth = send_node.children[1]
-          rbs_type = resolve_rbs_for_send(recv, meth, opts[:core_rbs_provider], opts[:local_var_types],
-                                          opts[:param_types])
-          return rbs_type if rbs_type
+          type = send_rbs_type(send_node.children[0], send_node.children[1], **opts)
+          return type if type
         end
 
         run_last_expr_type(node.children[2], **opts)
@@ -628,16 +628,29 @@ module Docscribe
         recv = node.children[0]
         meth = node.children[1]
 
-        if opts[:core_rbs_provider]
-          rbs_type = resolve_rbs_for_send(recv, meth, opts[:core_rbs_provider], opts[:local_var_types],
-                                          opts[:param_types])
-          return rbs_type if rbs_type
-        end
+        rbs_type = send_rbs_type(recv, meth, **opts) if opts[:core_rbs_provider]
+        return rbs_type if rbs_type
 
         compound_type = infer_from_compound_assign(node, **opts)
         return compound_type if compound_type
 
         Literals.type_from_literal(node, fallback_type: opts[:fallback_type])
+      end
+
+      # Resolve RBS return type for a send node, trying explicit receiver first,
+      # then falling back to the method's container for implicit self calls.
+      #
+      # @note module_function: defines #send_rbs_type (visibility: private)
+      # @param [Parser::AST::Node, nil] recv the receiver node
+      # @param [Symbol] meth the method name
+      # @param [Object] opts additional keyword options
+      # @return [String, nil]
+      def send_rbs_type(recv, meth, **opts)
+        rbs_type = resolve_rbs_for_send(recv, meth, opts[:core_rbs_provider], opts[:local_var_types],
+                                        opts[:param_types])
+        return rbs_type if rbs_type
+
+        container_rbs_return_type(meth, **opts) if recv.nil?
       end
 
       # Resolve RBS return type for a send node's receiver, if possible.
@@ -660,6 +673,31 @@ module Docscribe
 
         rbs = resolve_rbs_return_type(recv_type, meth, core_rbs_provider)
         rbs unless rbs == FALLBACK_TYPE
+      end
+
+      # Resolve return type from the current method's container via RBS.
+      #
+      # Handles implicit self calls (recv is nil) by looking up the method
+      # on the container class.
+      #
+      # @note module_function: defines #container_rbs_return_type (visibility: private)
+      # @param [Symbol] meth the method name being called
+      # @param [Object] opts additional keyword options (must include :container and :core_rbs_provider)
+      # @return [String, nil] resolved type or nil if unresolvable
+      def container_rbs_return_type(meth, **opts)
+        return unless opts[:container]
+
+        if opts[:core_rbs_provider]
+          rbs = resolve_rbs_return_type(opts[:container], meth, opts[:core_rbs_provider])
+          return rbs unless rbs == FALLBACK_TYPE
+        end
+
+        if opts[:signature_provider]
+          sig = opts[:signature_provider].signature_for(container: opts[:container], scope: :instance, name: meth)
+          return sig.return_type if sig
+        end
+
+        nil
       end
 
       # Map a receiver AST node to its RBS type name string.

--- a/lib/docscribe/inline_rewriter.rb
+++ b/lib/docscribe/inline_rewriter.rb
@@ -178,7 +178,7 @@ module Docscribe
       # @param [Docscribe::Config] config the active Docscribe::Config
       # @param [Object, nil] core_rbs_provider optional externally-provided core RBS provider
       # @raise [StandardError]
-      # @return [Object, nil] if StandardError
+      # @return [Object, nil]
       # @return [nil] if StandardError
       def load_core_rbs_provider(config, core_rbs_provider)
         core_rbs_provider || (config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil)
@@ -456,7 +456,7 @@ module Docscribe
       # @private
       # @param [Hash<Symbol, Object>, Docscribe::InlineRewriter::Collector::Insertion, Docscribe::InlineRewriter::Collector::AttrInsertion] insertion the collected method insertion
       # @raise [StandardError]
-      # @return [Integer] if StandardError
+      # @return [Integer]
       # @return [Integer] if StandardError
       def plugin_insertion_priority(insertion)
         return 0 unless insertion.is_a?(Hash)
@@ -471,7 +471,7 @@ module Docscribe
       # @private
       # @param [Hash<Symbol, Object>, Docscribe::InlineRewriter::Collector::Insertion, Docscribe::InlineRewriter::Collector::AttrInsertion] insertion the collected method insertion
       # @raise [StandardError]
-      # @return [String] if StandardError
+      # @return [String]
       # @return [String] if StandardError
       def plugin_insertion_label(insertion)
         return 'unknown' unless insertion.is_a?(Hash)
@@ -487,7 +487,7 @@ module Docscribe
       # @private
       # @param [Hash<Symbol, Object>, Docscribe::InlineRewriter::Collector::Insertion, Docscribe::InlineRewriter::Collector::AttrInsertion] insertion the collected method insertion
       # @raise [StandardError]
-      # @return [Integer, nil] if StandardError
+      # @return [Integer, nil]
       # @return [nil] if StandardError
       def plugin_insertion_line(insertion)
         return nil unless insertion.is_a?(Hash)
@@ -794,7 +794,9 @@ module Docscribe
       # @return [void]
       def merge_existing_descriptions!(params, parsed)
         params[:param_descriptions] = parsed[:param_descriptions] if parsed[:param_descriptions].any?
-        params[:return_description] = parsed[:return_description] if parsed[:return_description]
+        if parsed[:return_description] && !parsed[:return_description].start_with?('if ')
+          params[:return_description] = parsed[:return_description]
+        end
         params[:description] = parsed[:description] if parsed[:description].any?
       end
 
@@ -854,15 +856,7 @@ module Docscribe
       # @param [Docscribe::Config] config the active Docscribe::Config
       # @return [Hash<String, String>, nil]
       def resolve_param_types(insertion, external_sig, config)
-        if external_sig
-          DocBuilder.build_param_types_from_node(
-            insertion.node, external_sig: external_sig, config: config
-          )
-        else
-          DocBuilder.build_param_types_from_node(
-            insertion.node, external_sig: nil, config: config
-          )
-        end
+        DocBuilder.build_param_types_from_node(insertion.node, external_sig: external_sig, config: config)
       end
 
       # Apply method insertion aggressive
@@ -1240,7 +1234,7 @@ module Docscribe
       # @param [Docscribe::Config] config the active Docscribe::Config
       # @param [Docscribe::Types::ProviderChain, nil] signature_provider external RBS signature provider
       # @raise [StandardError]
-      # @return [String, nil] if StandardError
+      # @return [String, nil]
       # @return [nil] if StandardError
       def build_attr_merge_additions(ins:, existing_lines:, config:, signature_provider:)
         missing = missing_attr_names(ins, existing_lines)
@@ -1326,7 +1320,7 @@ module Docscribe
       # @param [Docscribe::Config] config the active Docscribe::Config
       # @param [Docscribe::Types::ProviderChain, nil] signature_provider external RBS signature provider
       # @raise [StandardError]
-      # @return [String, nil] if StandardError
+      # @return [String, nil]
       # @return [nil] if StandardError
       def build_attr_doc_for_node(ins, config:, signature_provider:)
         indent = SourceHelpers.line_indent(ins.node)
@@ -1447,8 +1441,8 @@ module Docscribe
       # @param [Docscribe::Config] config the active configuration
       # @param [Docscribe::Types::ProviderChain, nil] signature_provider RBS signature provider
       # @raise [StandardError]
+      # @return [String]
       # @return [String] if StandardError
-      # @return [Object] if StandardError
       def attribute_type(ins, name_sym, config, signature_provider:)
         ty = config.fallback_type
         return ty unless signature_provider
@@ -1466,8 +1460,8 @@ module Docscribe
       # @param [String] code the source code being processed
       # @param [String] file the file name
       # @raise [StandardError]
-      # @return [Object, nil] if StandardError
-      # @return [Object?] if StandardError
+      # @return [Object, nil]
+      # @return [Docscribe::Types::RBS::Provider, nil?] if StandardError
       def build_signature_provider(config, code, file)
         if config.respond_to?(:signature_provider_for)
           config.signature_provider_for(source: code, file: file)
@@ -1525,7 +1519,7 @@ module Docscribe
       # @private
       # @param [Docscribe::InlineRewriter::Collector::Insertion] insertion the collected method insertion
       # @raise [StandardError]
-      # @return [Integer] if StandardError
+      # @return [Integer]
       # @return [Object] if StandardError
       def method_line_for(insertion)
         anchor_node_for(insertion).loc.expression.line

--- a/lib/docscribe/inline_rewriter/doc_builder.rb
+++ b/lib/docscribe/inline_rewriter/doc_builder.rb
@@ -187,7 +187,9 @@ module Docscribe
       # @return [Hash<Symbol, Object>]
       def resolve_doc_setup!(setup, node, name, config, opts)
         external_sig = resolve_external_sig(setup[:container], setup[:scope], name, opts[:signature_provider])
-        returns_spec = compute_returns_spec(node, config, opts[:param_types], opts[:core_rbs_provider])
+        returns_spec = compute_returns_spec(node, config, opts[:param_types], opts[:core_rbs_provider],
+                                            signature_provider: opts[:signature_provider],
+                                            container: setup[:container])
         normal_type = opts[:return_type_override] || external_sig&.return_type || returns_spec[:normal]
 
         setup.merge(
@@ -229,11 +231,15 @@ module Docscribe
       # @param [Docscribe::Config] config Docscribe configuration object
       # @param [Hash<String, String>, nil] param_types hash accumulating parameter name-to-type mappings
       # @param [Object] core_rbs_provider RBS type provider
+      # @param [Docscribe::Types::ProviderChain?] signature_provider
+      # @param [String?] container
       # @return [Hash<Symbol, Object>]
-      def compute_returns_spec(node, config, param_types, core_rbs_provider)
+      def compute_returns_spec(node, config, param_types, core_rbs_provider, # rubocop:disable Metrics/ParameterLists
+                               signature_provider: nil, container: nil)
         Docscribe::Infer.returns_spec_from_node(
           node, fallback_type: config.fallback_type, nil_as_optional: config.nil_as_optional?,
-                param_types: param_types, core_rbs_provider: core_rbs_provider
+                param_types: param_types, core_rbs_provider: core_rbs_provider,
+                signature_provider: signature_provider, container: container
         )
       end
 

--- a/lib/docscribe/inline_rewriter/doc_builder.rb
+++ b/lib/docscribe/inline_rewriter/doc_builder.rb
@@ -67,7 +67,7 @@ module Docscribe
       # @param [Docscribe::Config] config Docscribe configuration object
       # @param [Object] opts additional keyword options forwarded to doc_setup
       # @raise [StandardError]
-      # @return [String, nil] if StandardError
+      # @return [String, nil]
       # @return [nil] if StandardError
       def build(insertion, config:, **opts)
         setup = doc_setup(insertion, config: config, **opts)
@@ -87,7 +87,7 @@ module Docscribe
       # @param [Docscribe::Config] config Docscribe configuration object
       # @param [Object] options additional keyword options forwarded to downstream methods
       # @raise [StandardError]
-      # @return [String, nil] if StandardError
+      # @return [String, nil]
       # @return [nil] if StandardError
       def build_merge_additions(insertion, existing_lines:, config:, **options)
         setup = doc_setup(insertion, config: config, **options)
@@ -110,7 +110,7 @@ module Docscribe
       # @param [Docscribe::Config] config Docscribe configuration object
       # @param [Object] options additional keyword options forwarded to downstream methods
       # @raise [StandardError]
-      # @return [Hash<Symbol, Object>] if StandardError
+      # @return [Hash<Symbol, Object>]
       # @return [Hash] if StandardError
       def build_missing_merge_result(insertion, existing_lines:, config:, **options)
         setup = doc_setup(insertion, config: config, **options)
@@ -696,7 +696,7 @@ module Docscribe
       # @note module_function: defines #extract_raise_types_from_line (visibility: private)
       # @param [String] line a `@raise` doc line
       # @raise [StandardError]
-      # @return [Array<String, nil>] if StandardError
+      # @return [Array<String, nil>]
       # @return [Array] if StandardError
       def extract_raise_types_from_line(line)
         return [] unless line.match?(/^\s*#\s*@raise\b/)
@@ -2004,7 +2004,7 @@ module Docscribe
       # @note module_function: defines #safe_node_source (visibility: private)
       # @param [Parser::AST::Node] node AST node whose source text to extract
       # @raise [StandardError]
-      # @return [String] if StandardError
+      # @return [String]
       # @return [String] if StandardError
       def safe_node_source(node)
         node.loc.expression.source

--- a/lib/docscribe/inline_rewriter/source_helpers.rb
+++ b/lib/docscribe/inline_rewriter/source_helpers.rb
@@ -260,7 +260,7 @@ module Docscribe
       # @note module_function: defines #line_indent (visibility: private)
       # @param [Parser::AST::Node] node target AST node
       # @raise [StandardError]
-      # @return [String] if StandardError
+      # @return [String]
       # @return [String] if StandardError
       def line_indent(node)
         line = node.loc.expression.source_line

--- a/lib/docscribe/lru_cache.rb
+++ b/lib/docscribe/lru_cache.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Docscribe
+  # Bounded LRU cache with O(1) access and eviction.
+  # Used by Server::Daemon for file rewrite caching.
+  class LRUCache
+    # @param [Integer] max_size
+    # @return [void]
+    def initialize(max_size = 1000)
+      @max_size = max_size
+      @data = {}
+    end
+
+    # @param [Object] key
+    # @return [Object]
+    def [](key)
+      val = @data[key]
+      return nil unless val
+
+      @data.delete(key)
+      @data[key] = val
+      val
+    end
+
+    # @param [Object] key
+    # @param [Object] val
+    # @return [Object]
+    def []=(key, val)
+      @data.delete(key) if @data.key?(key)
+      @data[key] = val
+      @data.shift if @data.size > @max_size
+    end
+
+    # @return [void]
+    def clear
+      @data.clear
+    end
+
+    # @return [Boolean]
+    def empty?
+      @data.empty?
+    end
+
+    # @return [Integer]
+    def size
+      @data.size
+    end
+  end
+end

--- a/lib/docscribe/parsing.rb
+++ b/lib/docscribe/parsing.rb
@@ -42,7 +42,7 @@ module Docscribe
       # @param [Parser::Source::Buffer] buffer prepared source buffer
       # @param [Symbol] backend :auto, :parser, or :prism
       # @raise [NoMethodError]
-      # @return [Parser::AST::Node, nil] if NoMethodError
+      # @return [Parser::AST::Node, nil]
       # @return [nil] if NoMethodError
       def parse_buffer(buffer, backend: :auto)
         parser = parser_for(backend: backend)
@@ -73,7 +73,7 @@ module Docscribe
       # @param [Parser::Source::Buffer] buffer prepared source buffer
       # @param [Symbol] backend :auto, :parser, or :prism
       # @raise [NoMethodError]
-      # @return [(Parser::AST::Node?, Array<Parser::Source::Comment>), nil] if NoMethodError
+      # @return [(Parser::AST::Node?, Array<Parser::Source::Comment>), nil]
       # @return [nil] if NoMethodError
       def parse_with_comments_buffer(buffer, backend: :auto)
         parser = parser_for(backend: backend)

--- a/lib/docscribe/plugin.rb
+++ b/lib/docscribe/plugin.rb
@@ -58,7 +58,7 @@ module Docscribe
     # @param [Parser::AST::Node] ast parsed AST root node
     # @param [Parser::Source::Buffer] buffer source buffer for AST
     # @raise [StandardError]
-    # @return [Array<Hash<Symbol, Object>>] if StandardError
+    # @return [Array<Hash<Symbol, Object>>]
     # @return [Array] if StandardError
     def self.process_single_plugin_result(entry, ast, buffer)
       plugin = entry.plugin

--- a/lib/docscribe/plugin/registry.rb
+++ b/lib/docscribe/plugin/registry.rb
@@ -54,7 +54,7 @@ module Docscribe
       # @param [String, Integer] priority plugin priority (higher wins for conflicts)
       # @raise [StandardError]
       # @raise [ArgumentError]
-      # @return [Integer] if StandardError
+      # @return [Integer]
       # @return [Object] if StandardError
       def parse_priority(priority)
         Integer(priority)

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -19,44 +19,44 @@ module Docscribe
     IDLE_TIMEOUT = 300
 
     class << self
-      # Start the server daemon and wait for it to become ready.
+      # Start the server daemon if not running.
       #
-      # @param [String?] config_path optional config path for socket/pid lookup
+      # @param [String?] config_path optional config file path
       # @param [Boolean] daemonize redirect stdin/stdout/stderr to /dev/null
       # @param [Integer] timeout max seconds to wait for readiness
       # @raise [StandardError]
       # @return [void]
       def ensure_running!(config_path: nil, daemonize: false, timeout: 5)
-        return if running?(config_path)
+        return if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
         raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
 
-        warn 'Docscribe: starting server...'
-        pid = Process.fork do # steep:ignore NoMethod
-          [$stdin, $stdout].each { _1.reopen(File::NULL) }
-          $stderr.reopen(File::NULL) if daemonize
-          Daemon.new(config_path: config_path).start
+        lock_path = "#{socket_path(config_path)}.lock"
+        File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
+          lock.flock(File::LOCK_EX)
+          next if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
+
+          start_daemon_process(config_path: config_path, daemonize: daemonize)
         end
-        Process.detach(pid)
         wait_for_ready(config_path: config_path, timeout: timeout)
       end
 
-      # Wait for the server to accept connections.
+      # Start the server daemon and wait for it to become ready.
       #
       # @param [String?] config_path optional config path for socket/pid lookup
-      # @param [Integer] timeout max seconds to wait
-      # @param [Boolean] raise_on_timeout raise vs warn on timeout
+      # @param [Integer] timeout max seconds to wait for readiness
+      # @param [Boolean] raise_on_timeout
       # @raise [StandardError]
-      # @return [void]
+      # @return [Boolean]
       def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true)
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         loop do
-          return if running?(config_path)
+          return true if running?(config_path)
 
           if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
             raise('Docscribe: server failed to start') if raise_on_timeout
 
             warn('Docscribe server failed to start within timeout')
-            return
+            return false
           end
 
           sleep 0.1
@@ -74,7 +74,7 @@ module Docscribe
       # @raise [Errno::ENOENT]
       # @raise [Errno::ENOTSOCK]
       # @raise [StandardError]
-      # @return [Boolean]
+      # @return [Boolean] if StandardError
       # @return [Boolean] if Errno::ECONNREFUSED
       # @return [Boolean] if Errno::ENOENT, Errno::ENOTSOCK
       # @return [Boolean] if StandardError
@@ -91,12 +91,9 @@ module Docscribe
         false
       end
 
-      private
-
       # Handle ECONNREFUSED: check if the pid process is alive.
       # Cleans up only if the process is dead.
       #
-      # @private
       # @param [String?] config_path
       # @return [Boolean] false (not running)
       def handle_stale_socket?(config_path)
@@ -107,10 +104,9 @@ module Docscribe
         false
       end
 
-      # @private
       # @param [Integer] pid
       # @raise [Errno::ESRCH]
-      # @return [Boolean]
+      # @return [Boolean] if Errno::ESRCH
       # @return [Boolean] if Errno::ESRCH
       def process_alive?(pid)
         Process.kill(0, pid)
@@ -121,7 +117,7 @@ module Docscribe
 
       # @param [String?] config_path
       # @raise [StandardError]
-      # @return [Integer?]
+      # @return [Integer?] if StandardError
       # @return [nil] if StandardError
       def read_pid(config_path = nil)
         File.read(pid_path(config_path)).to_i if File.exist?(pid_path(config_path))
@@ -130,7 +126,7 @@ module Docscribe
       end
 
       # Remove stale socket and pid files.
-      # @private
+      #
       # @param [String?] config_path
       # @return [void]
       def clean_socket_files(config_path)
@@ -164,9 +160,20 @@ module Docscribe
         end
       end
 
-      public :read_pid
-      public :pid_path
-      public :socket_path
+      public :read_pid, :pid_path, :socket_path
+
+      # @param [String?] config_path
+      # @param [Boolean] daemonize
+      # @return [void]
+      def start_daemon_process(config_path:, daemonize:)
+        warn 'Docscribe: starting server...'
+        pid = Process.fork do # steep:ignore NoMethod
+          [$stdin, $stdout].each { _1.reopen(File::NULL) }
+          $stderr.reopen(File::NULL) if daemonize
+          Daemon.new(config_path: config_path).start
+        end
+        Process.detach(pid)
+      end
     end
 
     # JSON-line protocol helpers.
@@ -224,18 +231,20 @@ module Docscribe
       #
       # @param [Object] file path to file to check
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
+      # @param [Hash] rest
       # @return [Object] response hash or nil if server unreachable
-      def check(file:, strategy: :safe)
-        request('check', file: file, strategy: strategy)
+      def check(file:, strategy: :safe, **rest)
+        request('check', file: file, strategy: strategy, **rest)
       end
 
       # Send a fix request to the server.
       #
       # @param [Object] file path to file to fix
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
+      # @param [Hash] rest
       # @return [Object] response hash or nil if server unreachable
-      def fix(file:, strategy: :safe)
-        request('fix', file: file, strategy: strategy)
+      def fix(file:, strategy: :safe, **rest)
+        request('fix', file: file, strategy: strategy, **rest)
       end
 
       # Send a shutdown request to the server.
@@ -286,7 +295,7 @@ module Docscribe
       # @param [nil] socket_path custom socket path
       # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
       # @param [nil] config_path custom config path
-      # @return [nil]
+      # @return [Hash]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
@@ -294,6 +303,7 @@ module Docscribe
         @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @running = false
         @server = nil
+        @file_cache = {}
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.
@@ -332,8 +342,6 @@ module Docscribe
         File.chmod(0o600, @socket_path)
       end
 
-      # Write PID file so clients can find the server process.
-      #
       # @private
       # @return [Object]
       def write_pid
@@ -349,7 +357,6 @@ module Docscribe
         while @running
           check_idle_timeout
           accept_client
-          @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
       rescue Interrupt
         @running = false
@@ -375,6 +382,7 @@ module Docscribe
         return unless client
 
         handle_client(client)
+        @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
       # Read a request from a client connection and dispatch it.
@@ -411,53 +419,69 @@ module Docscribe
         end
       end
 
-      # Handle a check request: read file, run rewriter, return results.
-      #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] params request parameters
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] params
       # @return [Object]
       def handle_check(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
         return send_error(client, id, -32_602, "File not found: #{file}") unless file && File.file?(file)
 
+        apply_cli_overrides(params['cli_overrides'])
         src, result = rewrite_file(file, strategy)
         send_result(client, id, 'status' => result[:output] == src ? 'ok' : 'fail',
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
       end
 
-      # Handle a fix request: read file, rewrite, write back.
-      #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] params request parameters
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] params
       # @return [Object]
       def handle_fix(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
         return send_error(client, id, -32_602, "File not found: #{file}") unless file && File.file?(file)
 
+        apply_cli_overrides(params['cli_overrides'])
         src, result = rewrite_file(file, strategy)
         File.write(file, result[:output]) if result[:output] != src
         send_result(client, id, 'status' => 'ok',
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
       end
 
-      # Read file, run InlineRewriter, and return [src, result].
-      #
       # @private
-      # @param [Object] file path to file
-      # @param [Object] strategy rewrite strategy
-      # @return [Array] original source and rewrite result
+      # @param [Object] overrides
+      # @return [Object]
+      def apply_cli_overrides(overrides)
+        return if overrides.nil? || overrides.empty?
+        return if @applied_overrides == overrides
+
+        config = @config or return
+        require 'docscribe/cli/config_builder'
+        opts = overrides.transform_keys(&:to_sym)
+        @effective_config = Docscribe::CLI::ConfigBuilder.build(config, opts)
+        @applied_overrides = overrides
+      end
+
+      # @private
+      # @param [Object] file
+      # @param [Object] strategy
+      # @raise [StandardError]
+      # @return [Array]
       def rewrite_file(file, strategy)
+        config = @effective_config || @config or raise 'Docscribe: config not loaded'
+        key = [file, strategy]
+        mtime = File.mtime(file)
+        hit = @file_cache[key]
+        return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
+
         src = File.read(file)
-        result = Docscribe::InlineRewriter.rewrite_with_report(
-          src, strategy: strategy, config: @config,
-               core_rbs_provider: @core_rbs_provider, file: file
-        )
+        rbs = config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil
+        result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: config, core_rbs_provider: rbs, file: file)
+        @file_cache[key] = { mtime: mtime, src: src, result: result }
         [src, result]
       end
 
@@ -478,23 +502,21 @@ module Docscribe
       # @param [Object] client connected client socket
       # @param [Object] id request ID
       # @param [Object] result result data
-      # @return [nil]
+      # @return [Object]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }
-        client.puts(Protocol.serialize(response))
+        client.write(Protocol.serialize(response))
       end
 
-      # Send a JSON-RPC error response.
-      #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] code error code
-      # @param [Object] message error message
-      # @return [nil]
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] code
+      # @param [Object] message
+      # @return [Object]
       def send_error(client, id, code, message)
         response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
-        client.puts(Protocol.serialize(response))
+        client.write(Protocol.serialize(response))
       end
 
       # Cleanup socket and PID files on shutdown.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -1,0 +1,427 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'socket'
+require 'fileutils'
+require 'securerandom'
+require 'digest/md5'
+
+module Docscribe
+  # Server/daemon mode for persistent multi-request operation.
+  #
+  # Architecture:
+  # - Daemon process loads Ruby runtime once, listens on a Unix socket
+  # - Client sends JSON-line requests, receives JSON-line responses
+  # - Auto-shutdown after idle timeout
+  # - Protocol: JSON-RPC 2.0 over Unix socket
+  module Server
+    SOCKET_DIR = '/tmp'
+    IDLE_TIMEOUT = 300
+
+    class << self
+      # Whether a server process is listening on the socket.
+      #
+      # @param [String?] config_path optional config path for socket lookup
+      # @raise [Errno::ECONNREFUSED]
+      # @raise [Errno::ENOENT]
+      # @raise [Errno::ENOTSOCK]
+      # @raise [StandardError]
+      # @return [Boolean] if StandardError
+      # @return [Boolean] if Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
+      # @return [Boolean] if StandardError
+      def running?(config_path = nil)
+        socket = UNIXSocket.new(socket_path(config_path))
+        socket.close
+        true
+      rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
+        FileUtils.rm_f(socket_path(config_path))
+        FileUtils.rm_f(pid_path(config_path))
+        false
+      rescue StandardError
+        false
+      end
+
+      # Read the PID of the running server process.
+      #
+      # @param [String?] config_path optional config path for socket lookup
+      # @raise [StandardError]
+      # @return [Integer?] if StandardError
+      # @return [nil] if StandardError
+      def read_pid(config_path = nil)
+        File.read(pid_path(config_path)).to_i if File.exist?(pid_path(config_path))
+      rescue StandardError
+        nil
+      end
+
+      # Path to the PID file for the server process.
+      #
+      # @param [String?] config_path optional config path for socket lookup
+      # @return [String]
+      def pid_path(config_path = nil)
+        "#{socket_path(config_path)}.pid"
+      end
+
+      # Derive a project-specific socket path from the current working directory.
+      # Uses MD5 (deterministic across processes) instead of String#hash
+      # (which varies per Ruby process due to random seeding).
+      # When a config_path is given, its path + mtime are included in the hash
+      # so different configs get different daemons.
+      #
+      # @param [String?] config_path optional config path to differentiate
+      # @return [String]
+      def socket_path(config_path = nil)
+        hash = Digest::MD5.hexdigest(Dir.pwd)
+        if config_path
+          cfg_hash = Digest::MD5.hexdigest("#{config_path}:#{File.mtime(config_path).to_i}")
+          "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
+        else
+          "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+        end
+      end
+    end
+
+    # JSON-line protocol helpers.
+    module Protocol
+      module_function
+
+      # Build a JSON-RPC request hash.
+      #
+      # @note module_function: defines #build_request (visibility: private)
+      # @param [String] method method name
+      # @param [Hash<Symbol, Object>] params request parameters
+      # @return [Hash<Symbol, Object>]
+      def build_request(method, params = {})
+        {
+          jsonrpc: '2.0',
+          id: SecureRandom.hex(8),
+          method: method,
+          params: params
+        }
+      end
+
+      # Parse a single JSON-line response.
+      #
+      # @note module_function: defines #parse_response (visibility: private)
+      # @param [String] line raw JSON line
+      # @raise [JSON::ParserError]
+      # @return [Hash<String, Object>?] if JSON::ParserError
+      # @return [nil] if JSON::ParserError
+      def parse_response(line)
+        JSON.parse(line)
+      rescue JSON::ParserError
+        nil
+      end
+
+      # Serialize a hash to a JSON line.
+      #
+      # @note module_function: defines #serialize (visibility: private)
+      # @param [Hash<Object, Object>] hash
+      # @return [String]
+      def serialize(hash)
+        "#{JSON.generate(hash)}\n"
+      end
+    end
+
+    # Client for communicating with a running Docscribe daemon.
+    class Client
+      # @param [nil] socket_path custom socket path (defaults to server default)
+      # @param [nil] config_path optional config path for socket lookup
+      # @return [Object]
+      def initialize(socket_path = nil, config_path: nil)
+        @socket_path = socket_path || Server.socket_path(config_path)
+      end
+
+      # Send a check request to the server.
+      #
+      # @param [Object] file path to file to check
+      # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
+      # @return [Object] response hash or nil if server unreachable
+      def check(file:, strategy: :safe)
+        request('check', file: file, strategy: strategy)
+      end
+
+      # Send a fix request to the server.
+      #
+      # @param [Object] file path to file to fix
+      # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
+      # @return [Object] response hash or nil if server unreachable
+      def fix(file:, strategy: :safe)
+        request('fix', file: file, strategy: strategy)
+      end
+
+      # Send a shutdown request to the server.
+      #
+      # @return [Object] response hash or nil if server unreachable
+      def shutdown
+        request('shutdown')
+      end
+
+      private
+
+      # Send a JSON-RPC request and read the response.
+      #
+      # @private
+      # @param [Object] method method name
+      # @param [Hash] params request parameters
+      # @return [Object]
+      def request(method, **params)
+        connect do |socket|
+          req = Protocol.build_request(method, params)
+          socket.write(Protocol.serialize(req))
+          socket.close_write
+          line = socket.gets
+          break unless line
+
+          Protocol.parse_response(line)
+        end
+      end
+
+      # Connect to the Unix socket and yield the connection.
+      #
+      # @private
+      # @raise [Errno::ECONNREFUSED]
+      # @raise [Errno::ENOENT]
+      # @return [Object?, Object] yield return value or nil on connection error
+      def connect
+        socket = UNIXSocket.new(@socket_path)
+        yield socket
+      rescue Errno::ECONNREFUSED, Errno::ENOENT
+        nil
+      ensure
+        socket&.close
+      end
+    end
+
+    # Daemon process that loads the Ruby runtime once and serves requests.
+    class Daemon
+      # @param [nil] socket_path custom socket path
+      # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
+      # @param [nil] config_path custom config path
+      # @return [nil]
+      def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
+        @socket_path = socket_path || Server.socket_path(config_path)
+        @idle_timeout = idle_timeout
+        @config_path = config_path
+        @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @running = false
+        @server = nil
+      end
+
+      # Start the daemon: load dependencies, bind socket, enter listen loop.
+      #
+      # @return [Object]
+      def start
+        load_dependencies
+        setup_socket
+        @running = true
+        $PROGRAM_NAME = "docscribe server (#{Dir.pwd})"
+        write_pid
+        listen_loop
+      end
+
+      private
+
+      # Load the full Docscribe runtime and build cached config.
+      #
+      # @private
+      # @return [Object]
+      def load_dependencies
+        require 'docscribe'
+        @config = Docscribe::Config.load(@config_path)
+        @config&.load_plugins!
+        @core_rbs_provider = @config&.core_rbs_provider
+      end
+
+      # Create and bind the Unix domain socket.
+      #
+      # @private
+      # @return [Object]
+      def setup_socket
+        FileUtils.rm_f(@socket_path)
+        FileUtils.mkdir_p(File.dirname(@socket_path))
+        @server = UNIXServer.new(@socket_path)
+        File.chmod(0o600, @socket_path)
+      end
+
+      # Write PID file so clients can find the server process.
+      #
+      # @private
+      # @return [Object]
+      def write_pid
+        File.write("#{@socket_path}.pid", Process.pid)
+      end
+
+      # Main accept loop with idle timeout check.
+      #
+      # @private
+      # @raise [Interrupt]
+      # @return [Object, Boolean, Object]
+      def listen_loop
+        while @running
+          check_idle_timeout
+          accept_client
+          @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+      rescue Interrupt
+        @running = false
+      ensure
+        cleanup
+      end
+
+      # Check whether the idle timeout has been exceeded.
+      #
+      # @private
+      # @return [Boolean?]
+      def check_idle_timeout
+        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_request_time
+        @running = false if elapsed > @idle_timeout
+      end
+
+      # Accept a client connection if one is available.
+      #
+      # @private
+      # @return [Object]
+      def accept_client
+        client = @server&.accept if @server&.wait_readable(1)
+        return unless client
+
+        handle_client(client)
+      end
+
+      # Read a request from a client connection and dispatch it.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @raise [StandardError]
+      # @return [Object]
+      def handle_client(client)
+        request_line = client.gets or return
+        request = Protocol.parse_response(request_line)
+        request ? handle_request(client, request) : send_error(client, nil, -32_700, 'Parse error')
+      rescue StandardError => e
+        send_error(client, request&.dig('id'), -32_603, "#{e.class}: #{e.message}")
+      ensure
+        client.close
+      end
+
+      # Dispatch a parsed request to the appropriate handler.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @param [Object] request parsed JSON-RPC request
+      # @return [Object]
+      def handle_request(client, request)
+        method = request['method']
+        params = request['params'] || {}
+
+        case method
+        when 'check' then handle_check(client, request['id'], params)
+        when 'fix' then handle_fix(client, request['id'], params)
+        when 'shutdown' then handle_shutdown(client, request['id'])
+        else send_error(client, request['id'], -32_601, "Unknown method: #{method}")
+        end
+      end
+
+      # Handle a check request: read file, run rewriter, return results.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @param [Object] id request ID
+      # @param [Object] params request parameters
+      # @return [Object]
+      def handle_check(client, id, params)
+        file = params['file']
+        strategy = (params['strategy'] || 'safe').to_sym
+        return send_error(client, id, -32_602, "File not found: #{file}") unless file && File.file?(file)
+
+        src, result = rewrite_file(file, strategy)
+        send_result(client, id, 'status' => result[:output] == src ? 'ok' : 'fail',
+                                'changed' => result[:output] != src, 'changes' => result[:changes])
+      end
+
+      # Handle a fix request: read file, rewrite, write back.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @param [Object] id request ID
+      # @param [Object] params request parameters
+      # @return [Object]
+      def handle_fix(client, id, params)
+        file = params['file']
+        strategy = (params['strategy'] || 'safe').to_sym
+        return send_error(client, id, -32_602, "File not found: #{file}") unless file && File.file?(file)
+
+        src, result = rewrite_file(file, strategy)
+        File.write(file, result[:output]) if result[:output] != src
+        send_result(client, id, 'status' => 'ok',
+                                'changed' => result[:output] != src, 'changes' => result[:changes])
+      end
+
+      # Read file, run InlineRewriter, and return [src, result].
+      #
+      # @private
+      # @param [Object] file path to file
+      # @param [Object] strategy rewrite strategy
+      # @return [Array] original source and rewrite result
+      def rewrite_file(file, strategy)
+        src = File.read(file)
+        result = Docscribe::InlineRewriter.rewrite_with_report(
+          src, strategy: strategy, config: @config,
+               core_rbs_provider: @core_rbs_provider, file: file
+        )
+        [src, result]
+      end
+
+      # Handle a shutdown request.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @param [Object] id request ID
+      # @return [Boolean]
+      def handle_shutdown(client, id)
+        send_result(client, id, { 'status' => 'shutting_down' })
+        @running = false
+      end
+
+      # Send a JSON-RPC result response.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @param [Object] id request ID
+      # @param [Object] result result data
+      # @return [nil]
+      def send_result(client, id, result)
+        response = { jsonrpc: '2.0', id: id, result: result }
+        client.puts(Protocol.serialize(response))
+      end
+
+      # Send a JSON-RPC error response.
+      #
+      # @private
+      # @param [Object] client connected client socket
+      # @param [Object] id request ID
+      # @param [Object] code error code
+      # @param [Object] message error message
+      # @return [nil]
+      def send_error(client, id, code, message)
+        response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
+        client.puts(Protocol.serialize(response))
+      end
+
+      # Cleanup socket and PID files on shutdown.
+      #
+      # @private
+      # @raise [StandardError]
+      # @return [Object] if StandardError
+      # @return [nil] if StandardError
+      def cleanup
+        @server&.close
+        File.unlink(@socket_path) if @socket_path && File.exist?(@socket_path)
+        pid_path = "#{@socket_path}.pid"
+        FileUtils.rm_f(pid_path)
+      rescue StandardError
+        nil
+      end
+    end
+  end
+end

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -19,33 +19,109 @@ module Docscribe
     IDLE_TIMEOUT = 300
 
     class << self
+      # Start the server daemon and wait for it to become ready.
+      #
+      # @param [String?] config_path optional config path for socket/pid lookup
+      # @param [Boolean] daemonize redirect stdin/stdout/stderr to /dev/null
+      # @param [Integer] timeout max seconds to wait for readiness
+      # @raise [StandardError]
+      # @return [void]
+      def ensure_running!(config_path: nil, daemonize: false, timeout: 5)
+        return if running?(config_path)
+        raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
+
+        warn 'Docscribe: starting server...'
+        pid = Process.fork do # steep:ignore NoMethod
+          [$stdin, $stdout].each { _1.reopen(File::NULL) }
+          $stderr.reopen(File::NULL) if daemonize
+          Daemon.new(config_path: config_path).start
+        end
+        Process.detach(pid)
+        wait_for_ready(config_path: config_path, timeout: timeout)
+      end
+
+      # Wait for the server to accept connections.
+      #
+      # @param [String?] config_path optional config path for socket/pid lookup
+      # @param [Integer] timeout max seconds to wait
+      # @param [Boolean] raise_on_timeout raise vs warn on timeout
+      # @raise [StandardError]
+      # @return [void]
+      def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true)
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        loop do
+          return if running?(config_path)
+
+          if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+            raise('Docscribe: server failed to start') if raise_on_timeout
+
+            warn('Docscribe server failed to start within timeout')
+            return
+          end
+
+          sleep 0.1
+        end
+      end
+
       # Whether a server process is listening on the socket.
+      #
+      # On ECONNREFUSED, checks whether the PID process is still alive:
+      # if yes, the daemon is still starting up (don't clean up);
+      # if no, removes stale socket and pid files.
       #
       # @param [String?] config_path optional config path for socket lookup
       # @raise [Errno::ECONNREFUSED]
       # @raise [Errno::ENOENT]
       # @raise [Errno::ENOTSOCK]
       # @raise [StandardError]
-      # @return [Boolean] if StandardError
-      # @return [Boolean] if Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
+      # @return [Boolean]
+      # @return [Boolean] if Errno::ECONNREFUSED
+      # @return [Boolean] if Errno::ENOENT, Errno::ENOTSOCK
       # @return [Boolean] if StandardError
       def running?(config_path = nil)
         socket = UNIXSocket.new(socket_path(config_path))
         socket.close
         true
-      rescue Errno::ECONNREFUSED, Errno::ENOENT, Errno::ENOTSOCK
-        FileUtils.rm_f(socket_path(config_path))
-        FileUtils.rm_f(pid_path(config_path))
+      rescue Errno::ECONNREFUSED
+        handle_stale_socket?(config_path)
+      rescue Errno::ENOENT, Errno::ENOTSOCK
+        clean_socket_files(config_path)
         false
       rescue StandardError
         false
       end
 
-      # Read the PID of the running server process.
+      private
+
+      # Handle ECONNREFUSED: check if the pid process is alive.
+      # Cleans up only if the process is dead.
       #
-      # @param [String?] config_path optional config path for socket lookup
+      # @private
+      # @param [String?] config_path
+      # @return [Boolean] false (not running)
+      def handle_stale_socket?(config_path)
+        pid = read_pid(config_path)
+        return false if pid && process_alive?(pid)
+
+        clean_socket_files(config_path)
+        false
+      end
+
+      # @private
+      # @param [Integer] pid
+      # @raise [Errno::ESRCH]
+      # @return [Boolean]
+      # @return [Boolean] if Errno::ESRCH
+      def process_alive?(pid)
+        Process.kill(0, pid)
+        true
+      rescue Errno::ESRCH
+        false
+      end
+
+      # @param [String?] config_path
       # @raise [StandardError]
-      # @return [Integer?] if StandardError
+      # @return [Integer?]
       # @return [nil] if StandardError
       def read_pid(config_path = nil)
         File.read(pid_path(config_path)).to_i if File.exist?(pid_path(config_path))
@@ -53,9 +129,16 @@ module Docscribe
         nil
       end
 
-      # Path to the PID file for the server process.
-      #
-      # @param [String?] config_path optional config path for socket lookup
+      # Remove stale socket and pid files.
+      # @private
+      # @param [String?] config_path
+      # @return [void]
+      def clean_socket_files(config_path)
+        FileUtils.rm_f(socket_path(config_path))
+        FileUtils.rm_f(pid_path(config_path))
+      end
+
+      # @param [String?] config_path
       # @return [String]
       def pid_path(config_path = nil)
         "#{socket_path(config_path)}.pid"
@@ -72,12 +155,18 @@ module Docscribe
       def socket_path(config_path = nil)
         hash = Digest::MD5.hexdigest(Dir.pwd)
         if config_path
-          cfg_hash = Digest::MD5.hexdigest("#{config_path}:#{File.mtime(config_path).to_i}")
+          resolved = File.expand_path(config_path)
+          mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+          cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
           "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
         else
           "#{SOCKET_DIR}/docscribe-#{hash}.sock"
         end
       end
+
+      public :read_pid
+      public :pid_path
+      public :socket_path
     end
 
     # JSON-line protocol helpers.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -481,6 +481,7 @@ module Docscribe
         require 'docscribe/cli/config_builder'
         opts = overrides.transform_keys(&:to_sym)
         @effective_config = Docscribe::CLI::ConfigBuilder.build(config, opts)
+        @file_cache.clear
         @applied_overrides = overrides
       end
 

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -37,13 +37,13 @@ module Docscribe
       # @raise [StandardError]
       # @return [void]
       def ensure_running!(config_path: nil, daemonize: false, timeout: 5)
-        return if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
+        return if running?(config_path)
         raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
 
         lock_path = "#{socket_path(config_path)}.lock"
         File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
           lock.flock(File::LOCK_EX)
-          next if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
+          next if running?(config_path)
 
           start_daemon_process(config_path: config_path, daemonize: daemonize)
         end
@@ -57,7 +57,7 @@ module Docscribe
       # @param [Boolean] raise_on_timeout
       # @raise [StandardError]
       # @return [Boolean]
-      def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true)
+      def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true) # rubocop:disable SortedMethodsByCall/Waterfall
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         loop do
           return true if running?(config_path)
@@ -202,7 +202,7 @@ module Docscribe
         warn 'Docscribe: starting server...' if daemonize
         pid = Process.fork do # steep:ignore NoMethod
           [$stdin, $stdout].each { _1.reopen(File::NULL) }
-          $stderr.reopen(File::NULL) if daemonize
+          $stderr.reopen(File::NULL)
           Daemon.new(config_path: config_path).start
         end
         Process.detach(pid)

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -5,6 +5,7 @@ require 'socket'
 require 'fileutils'
 require 'securerandom'
 require 'digest/md5'
+require_relative 'lru_cache'
 
 module Docscribe
   # Server/daemon mode for persistent multi-request operation.
@@ -169,6 +170,7 @@ module Docscribe
 
       # Hash of environment files that affect analysis results.
       # When any of these change, the daemon is invalidated (new socket path).
+      #
       # @return [String]
       def env_hash
         parts = ENV_FILES.map do |file|
@@ -313,7 +315,7 @@ module Docscribe
       # @param [nil] socket_path custom socket path
       # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
       # @param [nil] config_path custom config path
-      # @return [Hash]
+      # @return [LRUCache]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
@@ -321,7 +323,7 @@ module Docscribe
         @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @running = false
         @server = nil
-        @file_cache = {}
+        @file_cache = LRUCache.new
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -75,7 +75,7 @@ module Docscribe
       # @raise [Errno::ENOENT]
       # @raise [Errno::ENOTSOCK]
       # @raise [StandardError]
-      # @return [Boolean] if StandardError
+      # @return [Boolean]
       # @return [Boolean] if Errno::ECONNREFUSED
       # @return [Boolean] if Errno::ENOENT, Errno::ENOTSOCK
       # @return [Boolean] if StandardError
@@ -107,7 +107,7 @@ module Docscribe
 
       # @param [Integer] pid
       # @raise [Errno::ESRCH]
-      # @return [Boolean] if Errno::ESRCH
+      # @return [Boolean]
       # @return [Boolean] if Errno::ESRCH
       def process_alive?(pid)
         Process.kill(0, pid)
@@ -118,7 +118,7 @@ module Docscribe
 
       # @param [String?] config_path
       # @raise [StandardError]
-      # @return [Integer?] if StandardError
+      # @return [Integer?]
       # @return [nil] if StandardError
       def read_pid(config_path = nil)
         File.read(pid_path(config_path)).to_i if File.exist?(pid_path(config_path))
@@ -220,7 +220,7 @@ module Docscribe
       # @note module_function: defines #parse_response (visibility: private)
       # @param [String] line raw JSON line
       # @raise [JSON::ParserError]
-      # @return [Hash<String, Object>?] if JSON::ParserError
+      # @return [Hash<String, Object>?]
       # @return [nil] if JSON::ParserError
       def parse_response(line)
         JSON.parse(line)
@@ -242,7 +242,7 @@ module Docscribe
     class Client
       # @param [nil] socket_path custom socket path (defaults to server default)
       # @param [nil] config_path optional config path for socket lookup
-      # @return [Object]
+      # @return [Object, nil]
       def initialize(socket_path = nil, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
       end
@@ -476,7 +476,7 @@ module Docscribe
       # @param [Object] overrides
       # @return [Object]
       def apply_cli_overrides(overrides)
-        return if overrides.nil? || overrides.empty?
+        return reset_effective_config if overrides.nil? || overrides.empty?
         return if @applied_overrides == overrides
 
         config = @config or return
@@ -485,6 +485,16 @@ module Docscribe
         @effective_config = Docscribe::CLI::ConfigBuilder.build(config, opts)
         @file_cache.clear
         @applied_overrides = overrides
+      end
+
+      # @private
+      # @return [Object]
+      def reset_effective_config
+        return unless @effective_config
+
+        @effective_config = nil
+        @applied_overrides = nil
+        @file_cache.clear
       end
 
       # @private
@@ -544,7 +554,7 @@ module Docscribe
       #
       # @private
       # @raise [StandardError]
-      # @return [Object] if StandardError
+      # @return [Object]
       # @return [nil] if StandardError
       def cleanup
         @server&.close

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -23,7 +23,7 @@ module Docscribe
     # that exceeds this limit, so we fall back to /tmp when needed.
     SOCKET_DIR = begin
       tmp = Dir.tmpdir || '/tmp'
-      sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize # 80
+      sock_overhead = "/docscribe-#{'a' * 32}.sock".bytesize # 48
       tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
     end
     IDLE_TIMEOUT = 300
@@ -163,10 +163,14 @@ module Docscribe
       # @param [String?] config_path optional config path to differentiate
       # @return [String]
       def socket_path(config_path = nil)
-        hash = Digest::MD5.hexdigest(Dir.pwd)
-        env_seed = env_hash
-        suffix = config_path ? "-#{config_hash(config_path)}" : ''
-        "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+        seed = +Dir.pwd
+        seed << ":#{env_hash}"
+        if config_path
+          resolved = File.expand_path(config_path)
+          mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+          seed << ":#{resolved}:#{mtime}"
+        end
+        "#{SOCKET_DIR}/docscribe-#{Digest::MD5.hexdigest(seed)}.sock"
       end
 
       # @param [String] config_path

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -5,6 +5,8 @@ require 'socket'
 require 'fileutils'
 require 'securerandom'
 require 'digest/md5'
+require 'tmpdir'
+require 'time'
 require_relative 'lru_cache'
 
 module Docscribe
@@ -16,7 +18,14 @@ module Docscribe
   # - Auto-shutdown after idle timeout
   # - Protocol: JSON-RPC 2.0 over Unix socket
   module Server
-    SOCKET_DIR = '/tmp'
+    # Unix socket path max is 104 bytes on macOS (the more restrictive).
+    # Dir.tmpdir on macOS often returns a long path under /var/folders/.../T
+    # that exceeds this limit, so we fall back to /tmp when needed.
+    SOCKET_DIR = begin
+      tmp = Dir.tmpdir || '/tmp'
+      sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize # 80
+      tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
+    end
     IDLE_TIMEOUT = 300
 
     class << self
@@ -186,7 +195,7 @@ module Docscribe
       # @param [Boolean] daemonize
       # @return [void]
       def start_daemon_process(config_path:, daemonize:)
-        warn 'Docscribe: starting server...'
+        warn 'Docscribe: starting server...' if daemonize
         pid = Process.fork do # steep:ignore NoMethod
           [$stdin, $stdout].each { _1.reopen(File::NULL) }
           $stderr.reopen(File::NULL) if daemonize
@@ -240,38 +249,45 @@ module Docscribe
 
     # Client for communicating with a running Docscribe daemon.
     class Client
-      # @param [nil] socket_path custom socket path (defaults to server default)
-      # @param [nil] config_path optional config path for socket lookup
-      # @return [Object, nil]
+      # @param [String?] socket_path custom socket path (defaults to server default)
+      # @param [String?] config_path optional config path for socket lookup
+      # @return [void]
       def initialize(socket_path = nil, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
       end
 
       # Send a check request to the server.
       #
-      # @param [Object] file path to file to check
+      # @param [String] file path to file to check
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
-      # @param [Hash] rest
-      # @return [Object] response hash or nil if server unreachable
+      # @param [Object] rest
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def check(file:, strategy: :safe, **rest)
         request('check', file: file, strategy: strategy, **rest)
       end
 
       # Send a fix request to the server.
       #
-      # @param [Object] file path to file to fix
+      # @param [String] file path to file to fix
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
-      # @param [Hash] rest
-      # @return [Object] response hash or nil if server unreachable
+      # @param [Object] rest
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def fix(file:, strategy: :safe, **rest)
         request('fix', file: file, strategy: strategy, **rest)
       end
 
       # Send a shutdown request to the server.
       #
-      # @return [Object] response hash or nil if server unreachable
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def shutdown
         request('shutdown')
+      end
+
+      # Ping the server and get version/pid/uptime info.
+      #
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
+      def ping
+        request('ping')
       end
 
       private
@@ -279,9 +295,9 @@ module Docscribe
       # Send a JSON-RPC request and read the response.
       #
       # @private
-      # @param [Object] method method name
-      # @param [Hash] params request parameters
-      # @return [Object]
+      # @param [String] method method name
+      # @param [Object] params request parameters
+      # @return [Hash<String, Object>?]
       def request(method, **params)
         connect do |socket|
           req = Protocol.build_request(method, params)
@@ -299,7 +315,7 @@ module Docscribe
       # @private
       # @raise [Errno::ECONNREFUSED]
       # @raise [Errno::ENOENT]
-      # @return [Object?, Object] yield return value or nil on connection error
+      # @return [T?] yield return value or nil on connection error
       def connect
         socket = UNIXSocket.new(@socket_path)
         yield socket
@@ -312,10 +328,10 @@ module Docscribe
 
     # Daemon process that loads the Ruby runtime once and serves requests.
     class Daemon
-      # @param [nil] socket_path custom socket path
-      # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
-      # @param [nil] config_path custom config path
-      # @return [LRUCache]
+      # @param [String?] socket_path custom socket path
+      # @param [Integer] idle_timeout seconds before automatic shutdown
+      # @param [String?] config_path custom config path
+      # @return [void]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
@@ -324,11 +340,12 @@ module Docscribe
         @running = false
         @server = nil
         @file_cache = LRUCache.new
+        @started_at = Time.now
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.
       #
-      # @return [Object]
+      # @return [void]
       def start
         load_dependencies
         setup_socket
@@ -343,7 +360,7 @@ module Docscribe
       # Load the full Docscribe runtime and build cached config.
       #
       # @private
-      # @return [Object]
+      # @return [void]
       def load_dependencies
         require 'docscribe'
         @config = Docscribe::Config.load(@config_path)
@@ -354,7 +371,7 @@ module Docscribe
       # Create and bind the Unix domain socket.
       #
       # @private
-      # @return [Object]
+      # @return [void]
       def setup_socket
         FileUtils.rm_f(@socket_path)
         FileUtils.mkdir_p(File.dirname(@socket_path))
@@ -363,7 +380,7 @@ module Docscribe
       end
 
       # @private
-      # @return [Object]
+      # @return [void]
       def write_pid
         File.write("#{@socket_path}.pid", Process.pid)
       end
@@ -372,7 +389,7 @@ module Docscribe
       #
       # @private
       # @raise [Interrupt]
-      # @return [Object, Boolean, Object]
+      # @return [void]
       def listen_loop
         while @running
           check_idle_timeout
@@ -387,7 +404,7 @@ module Docscribe
       # Check whether the idle timeout has been exceeded.
       #
       # @private
-      # @return [Boolean?]
+      # @return [void]
       def check_idle_timeout
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_request_time
         @running = false if elapsed > @idle_timeout
@@ -396,7 +413,7 @@ module Docscribe
       # Accept a client connection if one is available.
       #
       # @private
-      # @return [Object]
+      # @return [void]
       def accept_client
         client = @server&.accept if @server&.wait_readable(1)
         return unless client
@@ -408,9 +425,9 @@ module Docscribe
       # Read a request from a client connection and dispatch it.
       #
       # @private
-      # @param [Object] client connected client socket
+      # @param [UNIXSocket] client connected client socket
       # @raise [StandardError]
-      # @return [Object]
+      # @return [void]
       def handle_client(client)
         request_line = client.gets or return
         request = Protocol.parse_response(request_line)
@@ -424,9 +441,9 @@ module Docscribe
       # Dispatch a parsed request to the appropriate handler.
       #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] request parsed JSON-RPC request
-      # @return [Object]
+      # @param [UNIXSocket] client connected client socket
+      # @param [Hash<String, Object>] request parsed JSON-RPC request
+      # @return [void]
       def handle_request(client, request)
         method = request['method']
         params = request['params'] || {}
@@ -435,15 +452,16 @@ module Docscribe
         when 'check' then handle_check(client, request['id'], params)
         when 'fix' then handle_fix(client, request['id'], params)
         when 'shutdown' then handle_shutdown(client, request['id'])
+        when 'ping' then handle_ping(client, request['id'])
         else send_error(client, request['id'], -32_601, "Unknown method: #{method}")
         end
       end
 
       # @private
-      # @param [Object] client
-      # @param [Object] id
-      # @param [Object] params
-      # @return [Object]
+      # @param [UNIXSocket] client
+      # @param [String, Integer] id
+      # @param [Hash<String, Object>] params
+      # @return [void]
       def handle_check(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -456,10 +474,10 @@ module Docscribe
       end
 
       # @private
-      # @param [Object] client
-      # @param [Object] id
-      # @param [Object] params
-      # @return [Object]
+      # @param [UNIXSocket] client
+      # @param [String, Integer] id
+      # @param [Hash<String, Object>] params
+      # @return [void]
       def handle_fix(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -473,8 +491,8 @@ module Docscribe
       end
 
       # @private
-      # @param [Object] overrides
-      # @return [Object]
+      # @param [Hash<String, Object>?] overrides
+      # @return [void]
       def apply_cli_overrides(overrides)
         return reset_effective_config if overrides.nil? || overrides.empty?
         return if @applied_overrides == overrides
@@ -488,7 +506,7 @@ module Docscribe
       end
 
       # @private
-      # @return [Object]
+      # @return [void]
       def reset_effective_config
         return unless @effective_config
 
@@ -498,10 +516,10 @@ module Docscribe
       end
 
       # @private
-      # @param [Object] file
-      # @param [Object] strategy
+      # @param [String] file
+      # @param [Symbol] strategy
       # @raise [StandardError]
-      # @return [Array]
+      # @return [(String, Hash<Symbol, Object>)]
       def rewrite_file(file, strategy)
         config = @effective_config || @config or raise 'Docscribe: config not loaded'
         key = [file, strategy]
@@ -519,32 +537,49 @@ module Docscribe
       # Handle a shutdown request.
       #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @return [Boolean]
+      # @param [UNIXSocket] client connected client socket
+      # @param [String, Integer] id request ID
+      # @return [void]
       def handle_shutdown(client, id)
         send_result(client, id, { 'status' => 'shutting_down' })
         @running = false
       end
 
+      # Handle a ping request.
+      #
+      # @private
+      # @param [UNIXSocket] client connected client socket
+      # @param [String, Integer] id request ID
+      # @return [void]
+      def handle_ping(client, id)
+        uptime = (Time.now - @started_at).to_i
+        send_result(client, id, {
+                      'version' => Docscribe::VERSION,
+                      'pid' => Process.pid,
+                      'socket_path' => @socket_path,
+                      'started_at' => @started_at.iso8601,
+                      'uptime' => uptime
+                    })
+      end
+
       # Send a JSON-RPC result response.
       #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] result result data
-      # @return [Object]
+      # @param [UNIXSocket] client connected client socket
+      # @param [String, Integer] id request ID
+      # @param [Hash<String, Object>] result result data
+      # @return [void]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }
         client.write(Protocol.serialize(response))
       end
 
       # @private
-      # @param [Object] client
-      # @param [Object] id
-      # @param [Object] code
-      # @param [Object] message
-      # @return [Object]
+      # @param [UNIXSocket] client
+      # @param [String, Integer, nil] id
+      # @param [Integer] code
+      # @param [String] message
+      # @return [void]
       def send_error(client, id, code, message)
         response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
         client.write(Protocol.serialize(response))
@@ -554,7 +589,7 @@ module Docscribe
       #
       # @private
       # @raise [StandardError]
-      # @return [Object]
+      # @return [void]
       # @return [nil] if StandardError
       def cleanup
         @server&.close

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -140,24 +140,42 @@ module Docscribe
         "#{socket_path(config_path)}.pid"
       end
 
+      ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
+
       # Derive a project-specific socket path from the current working directory.
       # Uses MD5 (deterministic across processes) instead of String#hash
       # (which varies per Ruby process due to random seeding).
       # When a config_path is given, its path + mtime are included in the hash
       # so different configs get different daemons.
+      # Environment files (Gemfile.lock, rbs_collection.lock.yaml) are also
+      # included so daemon is invalidated when gems or RBS types change.
       #
       # @param [String?] config_path optional config path to differentiate
       # @return [String]
       def socket_path(config_path = nil)
         hash = Digest::MD5.hexdigest(Dir.pwd)
-        if config_path
-          resolved = File.expand_path(config_path)
-          mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
-          cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
-          "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
-        else
-          "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+        env_seed = env_hash
+        suffix = config_path ? "-#{config_hash(config_path)}" : ''
+        "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+      end
+
+      # @param [String] config_path
+      # @return [String]
+      def config_hash(config_path)
+        resolved = File.expand_path(config_path)
+        mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+        Digest::MD5.hexdigest("#{resolved}:#{mtime}")
+      end
+
+      # Hash of environment files that affect analysis results.
+      # When any of these change, the daemon is invalidated (new socket path).
+      # @return [String]
+      def env_hash
+        parts = ENV_FILES.map do |file|
+          path = File.join(Dir.pwd, file)
+          File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
         end
+        Digest::MD5.hexdigest(parts.join(':'))
       end
 
       public :read_pid, :pid_path, :socket_path

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -227,13 +227,25 @@ module Docscribe
           return unless File.exist?(lock_path)
 
           lock = YAML.safe_load_file(lock_path) # steep:ignore
-          (lock['gems'] || []).each do |gem|
-            next unless gem['source'] && gem['source']['type'] == 'stdlib'
-
-            loader.add(library: gem['name']) # steep:ignore
-          end
+          (lock['gems'] || []).each { |gem| add_stdlib_gem(loader, gem) }
         rescue StandardError => e
-          warn "Docscribe: Failed to load stdlib RBS libraries: #{e.message}"
+          warn "Docscribe: Failed to parse rbs_collection.lock.yaml: #{e.message}"
+        end
+
+        # Add a single stdlib gem from the lock file to the loader.
+        #
+        # @private
+        # @param [RBS::EnvironmentLoader] loader
+        # @param [Object] gem gem entry from rbs_collection.lock.yaml
+        # @raise [StandardError]
+        # @return [void]
+        # @return [nil] if StandardError
+        def add_stdlib_gem(loader, gem)
+          return unless gem.is_a?(Hash) && gem.dig('source', 'type') == 'stdlib'
+
+          loader.add(library: gem['name']) # steep:ignore
+        rescue StandardError => e
+          warn "Docscribe: Failed to load stdlib RBS library '#{gem['name']}': #{e.message}"
         end
 
         # Build the appropriate instance or singleton definition for a container.

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -42,7 +42,7 @@ module Docscribe
         # @param [Symbol, String] name method name
         # @raise [::RBS::BaseError]
         # @raise [StandardError]
-        # @return [Docscribe::Types::MethodSignature, nil] if StandardError
+        # @return [Docscribe::Types::MethodSignature, nil]
         # @return [nil] if ::RBS::BaseError
         # @return [nil] if StandardError
         def signature_for(container:, scope:, name:)
@@ -105,7 +105,7 @@ module Docscribe
         # @param [Array<String>] collection_dirs RBS collection directories
         # @raise [::RBS::BaseError]
         # @raise [StandardError]
-        # @return [RBS::Environment] if ::RBS::BaseError
+        # @return [RBS::Environment]
         # @return [RBS::Environment] if ::RBS::BaseError
         def try_with_fallback_build_env(all_dirs, collection_dirs)
           # First attempt: load core types + all dirs (sig + collection).
@@ -179,7 +179,7 @@ module Docscribe
         #
         # @private
         # @raise [StandardError]
-        # @return [Array<String>] if StandardError
+        # @return [Array<String>]
         # @return [Array] if StandardError
         def stdlib_gem_names
           rbs_spec = Gem::Specification.find_by_name('rbs')

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'yaml'
 require 'docscribe/types/signature'
 require 'docscribe/types/rbs/type_formatter'
 require 'docscribe/types/rbs/collection_loader'
@@ -132,6 +133,7 @@ module Docscribe
         def build_env_with_collection(all_dirs, collection_dirs)
           loader = ::RBS::EnvironmentLoader.new
           loader.add(library: 'rbs') # steep:ignore
+          load_stdlib_libraries!(loader)
           add_dirs_to_loader!(loader, all_dirs, collection_dirs)
           env = ::RBS::Environment.from_loader(loader).resolve_type_names
           @builder = ::RBS::DefinitionBuilder.new(env: env)
@@ -197,6 +199,7 @@ module Docscribe
         def build_env(dirs)
           loader = ::RBS::EnvironmentLoader.new
           loader.add(library: 'rbs') # steep:ignore
+          load_stdlib_libraries!(loader)
 
           dirs.each do |dir|
             path = Pathname(dir)
@@ -206,6 +209,31 @@ module Docscribe
           env = ::RBS::Environment.from_loader(loader).resolve_type_names
           @builder = ::RBS::DefinitionBuilder.new(env: env)
           env
+        end
+
+        # Load stdlib RBS libraries declared in rbs_collection.lock.yaml.
+        #
+        # Without this, RBS types defined in user sig/ files (e.g. UNIXSocket)
+        # fail to resolve and the entire RBS environment breaks, causing all
+        # type lookups to silently fall back to inference.
+        #
+        # @private
+        # @param [RBS::EnvironmentLoader] loader
+        # @raise [StandardError]
+        # @return [void]
+        # @return [nil] if StandardError
+        def load_stdlib_libraries!(loader)
+          lock_path = File.join(Dir.pwd, 'rbs_collection.lock.yaml')
+          return unless File.exist?(lock_path)
+
+          lock = YAML.safe_load_file(lock_path) # steep:ignore
+          (lock['gems'] || []).each do |gem|
+            next unless gem['source'] && gem['source']['type'] == 'stdlib'
+
+            loader.add(library: gem['name']) # steep:ignore
+          end
+        rescue StandardError => e
+          warn "Docscribe: Failed to load stdlib RBS libraries: #{e.message}"
         end
 
         # Build the appropriate instance or singleton definition for a container.

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -106,18 +106,87 @@ module Docscribe
         # @raise [::RBS::BaseError]
         # @raise [StandardError]
         # @return [RBS::Environment] if ::RBS::BaseError
-        # @return [Object] if ::RBS::BaseError
+        # @return [RBS::Environment] if ::RBS::BaseError
         def try_with_fallback_build_env(all_dirs, collection_dirs)
-          build_env(all_dirs)
+          # First attempt: load core types + all dirs (sig + collection).
+          # If duplicate declarations occur (stdlib gem in both `library: 'rbs'`
+          # and collection), retry with individual collection gem dirs,
+          # skipping those already provided by the rbs stdlib.
+          build_env_with_collection(all_dirs, collection_dirs)
         rescue ::RBS::BaseError => e
           raise unless collection_dirs.any? && !@collection_dropped
 
           @collection_dropped = true
-          if ENV['DOCSCRIBE_RBS_DEBUG'] == '1'
-            warn "Docscribe: RBS collection error (#{e.class}), dropping collection dirs. " \
-                 'Set DOCSCRIBE_RBS_DEBUG=1 for details.'
-          end
+          warn "Docscribe: RBS collection error (#{e.class}), dropping collection dirs. " \
+               'Set DOCSCRIBE_RBS_DEBUG=1 for details.'
           build_env(@sig_dirs)
+        end
+
+        # Build the environment, handling potential duplicate declarations
+        # between rbs stdlib and collection gems.
+        #
+        # @private
+        # @param [Array<String>] all_dirs combined sig and collection dirs
+        # @param [Array<String>] collection_dirs RBS collection directories
+        # @return [RBS::Environment]
+        def build_env_with_collection(all_dirs, collection_dirs)
+          loader = ::RBS::EnvironmentLoader.new
+          loader.add(library: 'rbs') # steep:ignore
+          add_dirs_to_loader!(loader, all_dirs, collection_dirs)
+          env = ::RBS::Environment.from_loader(loader).resolve_type_names
+          @builder = ::RBS::DefinitionBuilder.new(env: env)
+          env
+        end
+
+        # Add directories to the loader, handling collection dirs separately.
+        #
+        # @private
+        # @param [RBS::EnvironmentLoader] loader
+        # @param [Array<String>] all_dirs
+        # @param [Array<String>] collection_dirs
+        # @return [void]
+        def add_dirs_to_loader!(loader, all_dirs, collection_dirs)
+          stdlib = stdlib_gem_names
+          all_dirs.each do |dir|
+            path = Pathname(dir)
+            next unless path.directory?
+
+            if collection_dirs.include?(dir)
+              add_collection_gem_dirs(loader, path, stdlib)
+            else
+              loader.add(path: path)
+            end
+          end
+        end
+
+        # Add individual collection gem directories to the loader.
+        #
+        # @private
+        # @param [RBS::EnvironmentLoader] loader
+        # @param [Pathname] path
+        # @param [Array<String>] stdlib
+        # @return [void]
+        def add_collection_gem_dirs(loader, path, stdlib)
+          path.children.each do |child|
+            next unless child.directory?
+            next if stdlib.include?(child.basename.to_s)
+
+            loader.add(path: child)
+          end
+        end
+
+        # Names of stdlib gems bundled with the `rbs` gem.
+        #
+        # @private
+        # @raise [StandardError]
+        # @return [Array<String>] if StandardError
+        # @return [Array] if StandardError
+        def stdlib_gem_names
+          rbs_spec = Gem::Specification.find_by_name('rbs')
+          stdlib_dir = File.join(rbs_spec.gem_dir, 'stdlib')
+          Dir.children(stdlib_dir)
+        rescue StandardError
+          []
         end
 
         # Build an RBS environment from the given directories.
@@ -127,7 +196,6 @@ module Docscribe
         # @return [RBS::Environment]
         def build_env(dirs)
           loader = ::RBS::EnvironmentLoader.new
-          # Load core types transitively
           loader.add(library: 'rbs') # steep:ignore
 
           dirs.each do |dir|
@@ -147,7 +215,10 @@ module Docscribe
         # @param [Symbol] scope :instance or :class
         # @return [RBS::Definition, nil]
         def definition_for(container:, scope:)
+          container = container.sub(/\[.*\]/, '').sub(/<.*>/, '')
           type_name = parse_type_name(absolute_const(container))
+          return nil unless @builder&.env&.type_name?(type_name)
+
           scope == :class ? @builder&.build_singleton(type_name) : @builder&.build_instance(type_name)
         end
 
@@ -311,13 +382,12 @@ module Docscribe
           end
         end
 
-        # Print one debug warning per provider instance when debugging is enabled.
+        # Print one warning per provider instance (avoiding repeated spam).
         #
         # @private
         # @param [String] msg warning message text
         # @return [void]
         def warn_once(msg)
-          return unless ENV['DOCSCRIBE_RBS_DEBUG'] == '1'
           return if @warned
 
           @warned = true

--- a/lib/docscribe/types/sorbet/base_provider.rb
+++ b/lib/docscribe/types/sorbet/base_provider.rb
@@ -52,7 +52,7 @@ module Docscribe
         # @raise [::RBS::BaseError]
         # @raise [SyntaxError]
         # @raise [StandardError]
-        # @return [void] if ::RBS::BaseError, SyntaxError, StandardError
+        # @return [void]
         # @return [nil] if LoadError
         # @return [nil] if ::RBS::BaseError, SyntaxError, StandardError
         def load_from_string(source, label:)

--- a/lib/docscribe/types/sorbet/base_provider.rb
+++ b/lib/docscribe/types/sorbet/base_provider.rb
@@ -18,10 +18,12 @@ module Docscribe
         # Initialize
         #
         # @param [Boolean] collapse_generics whether generic container details
+        # @param [Boolean] collapse_object_generics collapse Object generics
         # @return [void]
-        def initialize(collapse_generics: false)
+        def initialize(collapse_generics: false, collapse_object_generics: false)
           require 'rbs'
           @collapse_generics = !!collapse_generics
+          @collapse_object_generics = !!collapse_object_generics
           @index = {}
           @warned = false
         end
@@ -210,7 +212,8 @@ module Docscribe
         def format_type(type)
           Docscribe::Types::RBS::TypeFormatter.to_yard(
             type,
-            collapse_generics: @collapse_generics
+            collapse_generics: @collapse_generics,
+            collapse_object_generics: @collapse_object_generics
           )
         end
 
@@ -220,7 +223,7 @@ module Docscribe
         # @param [String] name method name
         # @return [String]
         def normalize_container(name)
-          name.to_s.delete_prefix('::')
+          name.to_s.delete_prefix('::').sub(/\[.*\]/, '').sub(/<.*>/, '')
         end
 
         # Print one debug warning per provider instance when debugging is enabled.

--- a/lib/docscribe/types/sorbet/rbi_provider.rb
+++ b/lib/docscribe/types/sorbet/rbi_provider.rb
@@ -16,9 +16,10 @@ module Docscribe
         #
         # @param [Array<String>] rbi_dirs directories scanned recursively for
         # @param [Boolean] collapse_generics whether generic container types
+        # @param [Boolean] collapse_object_generics collapse Object generics
         # @return [void]
-        def initialize(rbi_dirs:, collapse_generics: false)
-          super(collapse_generics: collapse_generics)
+        def initialize(rbi_dirs:, collapse_generics: false, collapse_object_generics: false)
+          super(collapse_generics: collapse_generics, collapse_object_generics: collapse_object_generics)
 
           Array(rbi_dirs).each do |dir|
             path = Pathname(dir)

--- a/lib/docscribe/types/sorbet/source_provider.rb
+++ b/lib/docscribe/types/sorbet/source_provider.rb
@@ -15,9 +15,10 @@ module Docscribe
         # @param [String] source Ruby source containing inline `sig` declarations
         # @param [String] file source label used in diagnostics/debug warnings
         # @param [Boolean] collapse_generics whether generic container types
+        # @param [Boolean] collapse_object_generics collapse Object generics
         # @return [void]
-        def initialize(source:, file:, collapse_generics: false)
-          super(collapse_generics: collapse_generics)
+        def initialize(source:, file:, collapse_generics: false, collapse_object_generics: false)
+          super(collapse_generics: collapse_generics, collapse_object_generics: collapse_object_generics)
           load_from_string(source, label: file)
         end
       end

--- a/lib/docscribe/version.rb
+++ b/lib/docscribe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Docscribe
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: diff-lcs
@@ -14,9 +14,13 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: digest
+  version: '0'
+  source:
+    type: stdlib
 - name: fileutils
   version: '0'
   source:
@@ -25,6 +29,14 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: io-console
+  version: '0'
+  source:
+    type: stdlib
+- name: irb-autosuggestions
+  version: 0.2.1
+  source:
+    type: rubygems
 - name: json
   version: '0'
   source:
@@ -34,13 +46,17 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
-  version: '0'
+  version: '1.7'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: monitor
   version: '0'
   source:
@@ -54,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -62,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -78,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -86,7 +102,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: random-formatter
@@ -106,7 +122,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -118,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -126,10 +142,18 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: rubocop-sorted_methods_by_call
+  version: 1.2.3
+  source:
+    type: rubygems
 - name: securerandom
+  version: '0'
+  source:
+    type: stdlib
+- name: socket
   version: '0'
   source:
     type: stdlib
@@ -146,7 +170,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -27,3 +27,5 @@ gems:
   - name: forwardable
   - name: strscan
   - name: securerandom
+  - name: socket
+  - name: digest

--- a/sig/lib/docscribe/cli.rbs
+++ b/sig/lib/docscribe/cli.rbs
@@ -4,7 +4,7 @@ module Docscribe
       def run: (Array[String]) -> Integer
     end
 
-    COMMANDS: Hash[String, _Subcommand]
+    COMMANDS: Hash[String, Symbol]
 
     def self.run: (Array[String] argv) -> Integer
 

--- a/sig/lib/docscribe/cli.rbs
+++ b/sig/lib/docscribe/cli.rbs
@@ -1,5 +1,11 @@
 module Docscribe
   module CLI
+    interface _Subcommand
+      def run: (Array[String]) -> Integer
+    end
+
+    COMMANDS: Hash[String, _Subcommand]
+
     def self.run: (Array[String] argv) -> Integer
 
     private

--- a/sig/lib/docscribe/cli/generate.rbs
+++ b/sig/lib/docscribe/cli/generate.rbs
@@ -1,6 +1,8 @@
 module Docscribe
   module CLI
     module Generate
+      BANNER: String
+
       PLUGIN_TYPES: Array["tag" | "collector"]
 
       NEXT_STEPS_TEMPLATE: String
@@ -26,8 +28,6 @@ module Docscribe
       def self.write_plugin: (String? content, plugin_type: String?, class_name: String?, output_dir: String?) -> (1 | 0)
 
       def self.build_option_parser: (Hash[Symbol, untyped] opts) -> OptionParser
-
-      def self.parser_banner: () -> String
 
       def self.register_output_option: (OptionParser opt, Hash[Symbol, untyped] opts) -> void
 

--- a/sig/lib/docscribe/cli/options.rbs
+++ b/sig/lib/docscribe/cli/options.rbs
@@ -1,9 +1,9 @@
 module Docscribe
   module CLI
     module Options
-      DEFAULT: { stdin: false, mode: :check, strategy: :safe, verbose: false, explain: false, quiet: false, format: :text, config: nil, include: Array[String], exclude: Array[String], include_file: Array[String], exclude_file: Array[String], rbs: false, sig_dirs: Array[String], sorbet: false, rbi_dirs: Array[String], rbs_collection: false, keep_descriptions: false, no_boilerplate: false, progress: false }
+      DEFAULT: { stdin: false, mode: :check, strategy: :safe, verbose: false, explain: false, quiet: false, format: :text, config: nil, include: Array[String], exclude: Array[String], include_file: Array[String], exclude_file: Array[String], rbs: false, sig_dirs: Array[String], sorbet: false, rbi_dirs: Array[String], rbs_collection: false, keep_descriptions: false, no_boilerplate: false, progress: false, server: false }
 
-      BANNER: "Usage: docscribe [options] [files...]\n\nDefault behavior:\n  Inspect files and report what safe doc updates would be applied.\n\nAutocorrect:\n    -a, --autocorrect              Apply safe doc updates in place\n                                   (insert missing docs, merge existing doc-like blocks,\n                                   normalize tag order)\n    -A, --autocorrect-all          Apply aggressive doc updates in place\n                                   (rebuild existing doc blocks)\n\nInput / config:\n        --stdin                    Read code from STDIN and print rewritten output\n    -C, --config PATH              Path to config YAML (default: docscribe.yml)\n\nType information:\n        --rbs                      Use RBS signatures for @param/@return when available\n        --sig-dir DIR              Add an RBS signature directory (repeatable). Implies `--rbs`.\n        --sorbet                   Use Sorbet signatures from inline sigs / RBI files when available\n        --rbi-dir DIR              Add a Sorbet RBI directory (repeatable). Implies --sorbet.\n        --rbs-collection           Auto-discover RBS collection from rbs_collection.lock.yaml. Implies --rbs.\n\nFiltering:\n        --include PATTERN          Include PATTERN (method id or file path; glob or /regex/)\n        --exclude PATTERN          Exclude PATTERN (method id or file path; glob or /regex/)\n        --include-file PATTERN     Only process files matching PATTERN (glob or /regex/)\n        --exclude-file PATTERN     Skip files matching PATTERN (glob or /regex/)\n\nOutput:\n        --verbose                  Print per-file actions\n        --progress                 Show progress [N/total] per file\n    -e, --explain                  Show detailed reasons for changes\n\nOther:\n    -v, --version                  Print version and exit\n    -h, --help                     Show this help\n"
+      BANNER: String
 
       def self?.parse!: (Array[String] argv) -> Formatters::opts
 
@@ -16,6 +16,8 @@ module Docscribe
       def self?.define_stdin_option: (OptionParser opts, Hash[Symbol, untyped] options) -> void
 
       def self?.define_config_option: (OptionParser opts, Hash[Symbol, untyped] options) -> void
+
+      def self?.define_server_option: (OptionParser opts, Hash[Symbol, untyped] options) -> void
 
       def self?.define_type_options: (OptionParser opts, Hash[Symbol, untyped] options) -> void
 

--- a/sig/lib/docscribe/cli/run.rbs
+++ b/sig/lib/docscribe/cli/run.rbs
@@ -5,6 +5,10 @@ module Docscribe
 
       def self.run: (options: Formatters::opts, argv: Array[String]) -> Integer
 
+      def self.run_via_server: (options: Formatters::opts, argv: Array[String]) -> Integer
+
+      def self.run_files_via_server: (Docscribe::Server::Client client, Array[String] paths, Formatters::opts options) -> Integer
+
       def self.build_config: (Formatters::opts options) -> Config
 
       def self.run_stdin: (options: Formatters::opts, conf: Config) -> Integer
@@ -16,6 +20,28 @@ module Docscribe
       def self.filtered_paths: (Array[String] argv, Config conf) -> Array[String]
 
       def self.no_files_found: () -> Integer
+
+      def self.ensure_server_running!: (?config_path: String?) -> void
+
+      def self.wait_for_server: (?timeout: Integer, ?config_path: String?) -> void
+
+      def self.process_one_file_via_server: (Docscribe::Server::Client client, String path, options: Formatters::opts, pwd: Pathname, state: Formatters::state) -> void
+
+      def self.send_server_request: (Docscribe::Server::Client client, String path, Formatters::opts options) -> (Hash[String, untyped] | nil)
+
+      def self.server_error: (String path, Formatters::state state, String message) -> void
+
+      def self.dispatch_server_result: (Hash[String, untyped] result, Array[Formatters::change] file_changes, String path, **untyped ctx) -> void
+
+      def self.write_server_result: (Hash[String, untyped] result, Array[Formatters::change] file_changes, display_path: String, options: Formatters::opts, state: Formatters::state) -> void
+
+      def self.handle_via_server_check: (String path, file_changes: Array[Formatters::change], display_path: String, options: Formatters::opts, state: Formatters::state) -> void
+
+      def self.report_check_failure: (String display_path, Array[Formatters::change] file_changes, Formatters::opts options) -> void
+
+      def self.update_check_failure_state: (String path, Array[Formatters::change] file_changes, Formatters::state state) -> void
+
+      def self.symbolize_change: (Hash[String, untyped] change) -> Formatters::change
 
       def self.expand_paths: (Array[String] args) -> Array[String]
 

--- a/sig/lib/docscribe/cli/run.rbs
+++ b/sig/lib/docscribe/cli/run.rbs
@@ -3,9 +3,15 @@ module Docscribe
     module Run
       INITIAL_RUN_STATE: Formatters::state
 
+      CLI_OVERRIDE_KEYS: Array[Symbol]
+
       def self.run: (options: Formatters::opts, argv: Array[String]) -> Integer
 
       def self.run_via_server: (options: Formatters::opts, argv: Array[String]) -> Integer
+
+      def self.build_light_config: (Formatters::opts options) -> Config
+
+      def self.extract_cli_overrides: (Formatters::opts options) -> Hash[String, untyped]
 
       def self.run_files_via_server: (Docscribe::Server::Client client, Array[String] paths, Formatters::opts options) -> Integer
 

--- a/sig/lib/docscribe/cli/server.rbs
+++ b/sig/lib/docscribe/cli/server.rbs
@@ -1,0 +1,21 @@
+module Docscribe::CLI::ServerCmd
+  BANNER: String
+
+  def self.run: (Array[String] argv) -> Integer
+
+  private
+
+  def self.start_server: () -> Integer
+
+  def self.already_running: () -> Integer
+
+  def self.fork_and_wait: () -> void
+
+  def self.stop_server: () -> Integer
+
+  def self.show_status: () -> Integer
+
+  def self.usage: () -> String
+
+  def self.wait_for_startup: (?timeout: Integer) -> void
+end

--- a/sig/lib/docscribe/cli/server.rbs
+++ b/sig/lib/docscribe/cli/server.rbs
@@ -1,21 +1,14 @@
-module Docscribe::CLI::ServerCmd
-  BANNER: String
-
-  def self.run: (Array[String] argv) -> Integer
-
-  private
-
-  def self.start_server: () -> Integer
-
-  def self.already_running: () -> Integer
-
-  def self.fork_and_wait: () -> void
-
-  def self.stop_server: () -> Integer
-
-  def self.show_status: () -> Integer
-
-  def self.usage: () -> String
-
-  def self.wait_for_startup: (?timeout: Integer) -> void
+module Docscribe
+  module CLI
+    module ServerCmd
+      BANNER: String
+      def self?.run: (Array[String] argv) -> Integer
+      def self?.start_server: (?String? config_path) -> Integer
+      def self?.stop_server: (?String? config_path) -> Integer
+      def self?.show_status: (?String? config_path) -> Integer
+      def self?.already_running: (?String? config_path) -> Integer
+      def self?.parse_args: (Array[String] argv) -> [ String?, String? ]
+      def self?.usage: () -> String
+    end
+  end
 end

--- a/sig/lib/docscribe/cli/server.rbs
+++ b/sig/lib/docscribe/cli/server.rbs
@@ -6,6 +6,8 @@ module Docscribe
       def self?.start_server: (?String? config_path) -> Integer
       def self?.stop_server: (?String? config_path) -> Integer
       def self?.show_status: (?String? config_path) -> Integer
+      def self?.show_status_from_ping: (Hash[String, untyped] info) -> void
+      def self?.show_status_fallback: (String? config_path) -> void
       def self?.already_running: (?String? config_path) -> Integer
       def self?.parse_args: (Array[String] argv) -> [ String?, String? ]
       def self?.usage: () -> String

--- a/sig/lib/docscribe/config.rbs
+++ b/sig/lib/docscribe/config.rbs
@@ -1,9 +1,11 @@
 module Docscribe
   class Config
     @raw: Hash[String, Object]
+    @config_path: String?
 
     attr_reader raw: Hash[String, Object]
+    attr_reader config_path: String?
 
-    def initialize: (?Hash[String, Object] raw) -> void
+    def initialize: (?config_path: String?, **Hash[String, Object] raw) -> void
   end
 end

--- a/sig/lib/docscribe/config/sorbet.rbs
+++ b/sig/lib/docscribe/config/sorbet.rbs
@@ -17,5 +17,7 @@ module Docscribe
     def sorbet_rbi_dirs: () -> Array[String]
 
     def sorbet_collapse_generics?: () -> bool
+
+    def sorbet_collapse_object_generics?: () -> bool
   end
 end

--- a/sig/lib/docscribe/infer.rbs
+++ b/sig/lib/docscribe/infer.rbs
@@ -10,7 +10,7 @@ module Docscribe
 
     def self.infer_return_type_from_node: (Parser::AST::Node node) -> String
 
-        def self.returns_spec_from_node: (Parser::AST::Node node, ?fallback_type: String, ?nil_as_optional: bool, ?core_rbs_provider: Docscribe::Types::RBS::Provider?, ?param_types: Hash[String, String]?) -> { normal: String, rescues: Array[[Array[String], String]] }
+    def self.returns_spec_from_node: (Parser::AST::Node node, ?fallback_type: String, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?) -> { normal: String, rescues: Array[[Array[String], String]] }
 
     def self.last_expr_type: ((Parser::AST::Node | nil) node, ?fallback_type: String, ?nil_as_optional: bool) -> (String | nil)
 

--- a/sig/lib/docscribe/infer/returns.rbs
+++ b/sig/lib/docscribe/infer/returns.rbs
@@ -9,7 +9,7 @@ module Docscribe
 
       def self?.infer_return_type_from_node: (Parser::AST::Node node) -> String
 
-      def self?.returns_spec_from_node: (Parser::AST::Node node, ?fallback_type: String, ?nil_as_optional: bool, ?core_rbs_provider: untyped?, ?param_types: Hash[String, String]?) -> untyped
+      def self?.returns_spec_from_node: (Parser::AST::Node node, ?fallback_type: String, ?nil_as_optional: bool, ?core_rbs_provider: untyped?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?) -> untyped
 
       def self?.extract_def_body: (Parser::AST::Node node) -> (Parser::AST::Node | nil)
 
@@ -106,6 +106,10 @@ module Docscribe
       def self?.run_last_expr_type: ((Parser::AST::Node | nil) node, **untyped opts) -> (String | nil)
 
       def self?.handle_return_node: (Parser::AST::Node node, **untyped opts) -> (String | nil)
+
+      def self?.container_rbs_return_type: (Symbol meth, **untyped opts) -> (String | nil)
+
+      def self?.send_rbs_type: ((Parser::AST::Node | nil) recv, Symbol meth, **untyped opts) -> (String | nil)
 
       def self?.resolve_rbs_return_type: (String container_type, (String | Symbol) method_name, (untyped | nil) core_rbs_provider) -> String
 

--- a/sig/lib/docscribe/infer/returns.rbs
+++ b/sig/lib/docscribe/infer/returns.rbs
@@ -89,6 +89,8 @@ module Docscribe
 
       def self?.resolve_rbs_for_send: ((Parser::AST::Node | nil) recv, Symbol meth, (untyped | nil) core_rbs_provider, (Hash[untyped, untyped] | nil) local_var_types, (Hash[String, String] | nil) param_types) -> (String | nil)
 
+      def self?.resolve_rbs_for_send_with_signature_provider: ((Parser::AST::Node | nil) recv, Symbol meth, **untyped opts) -> (String | nil)
+
       def self?.receiver_rbs_type_name: ((Parser::AST::Node | nil) recv, (untyped | nil) core_rbs_provider, (Hash[untyped, untyped] | nil) local_var_types, (Hash[String, String] | nil) param_types) -> (String | nil)
 
       def self?.resolve_lvar_rbs: (Parser::AST::Node? recv, Symbol meth, (untyped | nil) core_rbs_provider, (Hash[untyped, untyped] | nil) local_var_types, (Hash[String, String] | nil) param_types) -> (String | nil)

--- a/sig/lib/docscribe/inline_rewriter/doc_builder.rbs
+++ b/sig/lib/docscribe/inline_rewriter/doc_builder.rbs
@@ -1,7 +1,7 @@
 module Docscribe
   module InlineRewriter
     module DocBuilder
-      PARAM_TYPE_COLLECTORS: Hash[Symbol, ^(Parser::AST::Node, Hash[String, String], (Docscribe::Types::MethodSignature | nil), Docscribe::Config) -> void]
+      PARAM_TYPE_COLLECTORS: Hash[Symbol, ^(Parser::AST::Node, Hash[String, String], (Types::MethodSignature | nil), Config) -> void]
 
       def self?.build: (untyped insertion, config: Config, **untyped) -> (String | nil)
 
@@ -19,9 +19,9 @@ module Docscribe
 
       def self?.extract_base_setup: (untyped insertion, Symbol name) -> Hash[Symbol, untyped]
 
-      def self?.resolve_external_sig: (String container, Symbol scope, Symbol name, (Docscribe::Types::ProviderChain | nil) signature_provider) -> (Docscribe::Types::MethodSignature | nil)
+      def self?.resolve_external_sig: (String container, Symbol scope, Symbol name, (Types::ProviderChain | nil) signature_provider) -> (Types::MethodSignature | nil)
 
-      def self?.compute_returns_spec: (Parser::AST::Node node, Config config, (Hash[String, String] | nil) param_types, untyped core_rbs_provider) -> Hash[Symbol, untyped]
+      def self?.compute_returns_spec: (Parser::AST::Node node, Config config, (Hash[String, String] | nil) param_types, untyped core_rbs_provider, ?container: String?, ?signature_provider: Types::ProviderChain?) -> Hash[Symbol, untyped]
 
       def self?.track_last_tag: (String content, Hash[Symbol, untyped] info) -> void
 
@@ -75,13 +75,13 @@ module Docscribe
 
       def self?.parse_raise_bracket_list: (String str) -> Array[String]
 
-      def self?.build_param_types_from_node: (Parser::AST::Node node, external_sig: (Docscribe::Types::MethodSignature | nil), config: Config) -> (Hash[String, String] | nil)
+      def self?.build_param_types_from_node: (Parser::AST::Node node, external_sig: (Types::MethodSignature | nil), config: Config) -> (Hash[String, String] | nil)
 
-      def self?.collect_all_param_types: (Parser::AST::Node args, Hash[String, String] param_types, (Docscribe::Types::MethodSignature | nil) external_sig, Config config) -> void
+      def self?.collect_all_param_types: (Parser::AST::Node args, Hash[String, String] param_types, (Types::MethodSignature | nil) external_sig, Config config) -> void
 
-      def self?.collect_param_type: (Parser::AST::Node arg_node, Hash[String, String] param_types, (Docscribe::Types::MethodSignature | nil) external_sig, Config config, infer_name: (^(String) -> String | nil)) -> void
+      def self?.collect_param_type: (Parser::AST::Node arg_node, Hash[String, String] param_types, (Types::MethodSignature | nil) external_sig, Config config, infer_name: (^(String) -> String | nil)) -> void
 
-      def self?.collect_optarg_param_type: (Parser::AST::Node arg_node, Hash[String, String] param_types, (Docscribe::Types::MethodSignature | nil) external_sig, Config config, infer_name: (^(String) -> String | nil)) -> void
+      def self?.collect_optarg_param_type: (Parser::AST::Node arg_node, Hash[String, String] param_types, (Types::MethodSignature | nil) external_sig, Config config, infer_name: (^(String) -> String | nil)) -> void
 
       def self?.merge_visibility_tag_lines: (String indent, Symbol visibility, Config config, Hash[Symbol, untyped] info) -> Array[String]
 
@@ -109,9 +109,9 @@ module Docscribe
 
       def self?.collect_updated_param: (String param_line, String pname, Array[String] lines, Array[Hash[Symbol, untyped]] reasons, Hash[Symbol, untyped] ctx) -> void
 
-      def self?.build_params_lines: (Parser::AST::Node node, String indent, external_sig: (Docscribe::Types::MethodSignature | nil), config: Config, ?param_types_override: (Hash[String, String] | nil), ?param_descriptions: (Hash[String, String] | nil)) -> (Array[String] | nil)
+      def self?.build_params_lines: (Parser::AST::Node node, String indent, external_sig: (Types::MethodSignature | nil), config: Config, ?param_types_override: (Hash[String, String] | nil), ?param_descriptions: (Hash[String, String] | nil)) -> (Array[String] | nil)
 
-      def self?.build_all_param_lines: (Parser::AST::Node args, String indent, Config config, ?external_sig: (Docscribe::Types::MethodSignature | nil), **untyped) -> (Array[String] | nil)
+      def self?.build_all_param_lines: (Parser::AST::Node args, String indent, Config config, ?external_sig: (Types::MethodSignature | nil), **untyped) -> (Array[String] | nil)
 
       def self?.build_doc_lines: (Hash[Symbol, untyped] setup, config: Config, **untyped) -> Array[String]
 
@@ -129,7 +129,7 @@ module Docscribe
 
       def self?.extract_args_from_node: (Parser::AST::Node node) -> (Parser::AST::Node | nil)
 
-      def self?.build_param_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> Array[String]
+      def self?.build_param_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> Array[String]
 
       def self?.build_header_lines: (String indent, config: Config, **untyped) -> Array[String]
 
@@ -147,27 +147,27 @@ module Docscribe
 
       def self?.build_plugin_tag_lines: (untyped insertion, String indent, String normal_type, (Array[untyped] | nil) override_tags) -> Array[String]
 
-      def self?.build_arg_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
+      def self?.build_arg_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
 
-      def self?.build_optarg_lines: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> Array[String]
+      def self?.build_optarg_lines: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> Array[String]
 
-      def self?.optarg_type: (String pname, Parser::AST::Node default, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, Hash[Symbol, untyped] opts) -> String
+      def self?.optarg_type: (String pname, Parser::AST::Node default, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, Hash[Symbol, untyped] opts) -> String
 
       def self?.source_from_node: (Parser::AST::Node node) -> (String | nil)
 
       def self?.resolve_infer_name: (String pname, (^(String) -> String | nil) infer_name) -> String
 
-      def self?.build_kwarg_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
+      def self?.build_kwarg_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
 
-      def self?.build_kwoptarg_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
+      def self?.build_kwoptarg_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
 
-      def self?.build_restarg_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
+      def self?.build_restarg_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
 
-      def self?.build_kwrestarg_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
+      def self?.build_kwrestarg_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
 
-      def self?.build_blockarg_line: (Parser::AST::Node arg_node, String indent, (Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
+      def self?.build_blockarg_line: (Parser::AST::Node arg_node, String indent, (Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, **untyped) -> String
 
-      def self?.lookup_param_type: ((Docscribe::Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, String pname, String infer_name, **untyped) -> String
+      def self?.lookup_param_type: ((Types::MethodSignature | nil) external_sig, (Hash[String, String] | nil) param_types_override, String pname, String infer_name, **untyped) -> String
 
       def self?.lookup_param_type_by_infer: ((Hash[String, String] | nil) param_types_override, String pname, String infer_name, String fallback_type, (bool | nil) treat_options_keyword_as_hash) -> String
 

--- a/sig/lib/docscribe/lru_cache.rbs
+++ b/sig/lib/docscribe/lru_cache.rbs
@@ -1,0 +1,13 @@
+module Docscribe
+  class LRUCache
+    @max_size: Integer
+    @data: Hash[untyped, untyped]
+
+    def initialize: (?Integer max_size) -> void
+    def []: (untyped key) -> untyped
+    def []=: (untyped key, untyped val) -> untyped
+    def clear: () -> void
+    def empty?: () -> bool
+    def size: () -> Integer
+  end
+end

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -1,3 +1,7 @@
+class Dir
+  def self?.tmpdir: () -> String
+end
+
 module Docscribe
   module Server
     SOCKET_DIR: String
@@ -31,6 +35,7 @@ module Docscribe
       def fix: (file: String, ?strategy: Symbol, **untyped) -> Hash[String, untyped]?
 
       def shutdown: () -> Hash[String, untyped]?
+      def ping: () -> Hash[String, untyped]?
 
       private
 
@@ -49,6 +54,7 @@ module Docscribe
       @core_rbs_provider: untyped
       @file_cache: Docscribe::LRUCache
       @effective_config: Docscribe::Config?
+      @started_at: Time
       @applied_overrides: Hash[String, untyped]?
 
       def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
@@ -70,6 +76,7 @@ module Docscribe
       def reset_effective_config: () -> void
       def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
+      def handle_ping: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def send_error: (UNIXSocket, (String | Integer | nil), Integer, String) -> void
       def cleanup: () -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -8,7 +8,8 @@ module Docscribe
     def self?.pid_path: (?String? config_path) -> String
     def self?.socket_path: (?String? config_path) -> String
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
-    def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> void
+    def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> bool
+    def self?.start_daemon_process: (config_path: String?, daemonize: bool) -> void
     def self?.handle_stale_socket?: (String? config_path) -> bool
     def self?.process_alive?: (Integer pid) -> bool
     def self?.clean_socket_files: (String? config_path) -> void
@@ -23,8 +24,8 @@ module Docscribe
       @socket_path: String
 
       def initialize: (?String? socket_path, ?config_path: String?) -> void
-      def check: (file: String, ?strategy: Symbol) -> Hash[String, untyped]?
-      def fix: (file: String, ?strategy: Symbol) -> Hash[String, untyped]?
+      def check: (file: String, ?strategy: Symbol, **untyped) -> Hash[String, untyped]?
+      def fix: (file: String, ?strategy: Symbol, **untyped) -> Hash[String, untyped]?
 
       def shutdown: () -> Hash[String, untyped]?
 
@@ -43,6 +44,9 @@ module Docscribe
       @config: Docscribe::Config?
       @config_path: String?
       @core_rbs_provider: untyped
+      @file_cache: untyped
+      @effective_config: Docscribe::Config?
+      @applied_overrides: Hash[String, untyped]?
 
       def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
       def start: () -> void
@@ -59,6 +63,7 @@ module Docscribe
       def handle_request: (UNIXSocket, Hash[String, untyped]) -> void
       def handle_check: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def handle_fix: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
+      def apply_cli_overrides: (Hash[String, untyped]?) -> void
       def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -1,0 +1,64 @@
+module Docscribe
+  module Server
+    SOCKET_DIR: String
+    IDLE_TIMEOUT: Integer
+
+    def self?.running?: (?String? config_path) -> bool
+    def self?.read_pid: (?String? config_path) -> Integer?
+    def self?.pid_path: (?String? config_path) -> String
+    def self?.socket_path: (?String? config_path) -> String
+
+    module Protocol
+      def self?.build_request: (String method, ?Hash[Symbol, untyped] params) -> Hash[Symbol, untyped]
+      def self?.parse_response: (String line) -> Hash[String, untyped]?
+      def self?.serialize: (Hash[untyped, untyped] hash) -> String
+    end
+
+    class Client
+      @socket_path: String
+
+      def initialize: (?String? socket_path, ?config_path: String?) -> void
+      def check: (file: String, ?strategy: Symbol) -> Hash[String, untyped]?
+      def fix: (file: String, ?strategy: Symbol) -> Hash[String, untyped]?
+
+      def shutdown: () -> Hash[String, untyped]?
+
+      private
+
+      def request: (String method, **untyped) -> Hash[String, untyped]?
+      def connect: [T] { (UNIXSocket) -> T } -> T?
+    end
+
+    class Daemon
+      @socket_path: String
+      @idle_timeout: Integer
+      @last_request_time: Numeric
+      @running: bool
+      @server: UNIXServer?
+      @config: Docscribe::Config?
+      @config_path: String?
+      @core_rbs_provider: untyped
+
+      def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
+      def start: () -> void
+
+      private
+
+      def load_dependencies: () -> void
+      def setup_socket: () -> void
+      def write_pid: () -> void
+      def listen_loop: () -> void
+      def check_idle_timeout: () -> void
+      def accept_client: () -> void
+      def handle_client: (UNIXSocket) -> void
+      def handle_request: (UNIXSocket, Hash[String, untyped]) -> void
+      def handle_check: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
+      def handle_fix: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
+      def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
+      def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
+      def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
+      def send_error: (UNIXSocket, (String | Integer | nil), Integer, String) -> void
+      def cleanup: () -> void
+    end
+  end
+end

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -2,11 +2,14 @@ module Docscribe
   module Server
     SOCKET_DIR: String
     IDLE_TIMEOUT: Integer
+    ENV_FILES: Array[String]
 
     def self?.running?: (?String? config_path) -> bool
     def self?.read_pid: (?String? config_path) -> Integer?
     def self?.pid_path: (?String? config_path) -> String
     def self?.socket_path: (?String? config_path) -> String
+    def self?.config_hash: (String config_path) -> String
+    def self?.env_hash: () -> String
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
     def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> bool
     def self?.start_daemon_process: (config_path: String?, daemonize: bool) -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -7,6 +7,11 @@ module Docscribe
     def self?.read_pid: (?String? config_path) -> Integer?
     def self?.pid_path: (?String? config_path) -> String
     def self?.socket_path: (?String? config_path) -> String
+    def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
+    def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> void
+    def self?.handle_stale_socket?: (String? config_path) -> bool
+    def self?.process_alive?: (Integer pid) -> bool
+    def self?.clean_socket_files: (String? config_path) -> void
 
     module Protocol
       def self?.build_request: (String method, ?Hash[Symbol, untyped] params) -> Hash[Symbol, untyped]

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -67,6 +67,7 @@ module Docscribe
       def handle_check: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def handle_fix: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def apply_cli_overrides: (Hash[String, untyped]?) -> void
+      def reset_effective_config: () -> void
       def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -47,7 +47,7 @@ module Docscribe
       @config: Docscribe::Config?
       @config_path: String?
       @core_rbs_provider: untyped
-      @file_cache: untyped
+      @file_cache: Docscribe::LRUCache
       @effective_config: Docscribe::Config?
       @applied_overrides: Hash[String, untyped]?
 

--- a/sig/lib/docscribe/types/rbs/provider.rbs
+++ b/sig/lib/docscribe/types/rbs/provider.rbs
@@ -39,6 +39,7 @@ module Docscribe
         def add_collection_gem_dirs: (::RBS::EnvironmentLoader loader, Pathname path, Array[String] stdlib) -> void
 
         def stdlib_gem_names: -> Array[String]
+        def load_stdlib_libraries!: (::RBS::EnvironmentLoader loader) -> void
 
         def definition_for: (container: String, scope: Symbol) -> (::RBS::Definition | nil)
 

--- a/sig/lib/docscribe/types/rbs/provider.rbs
+++ b/sig/lib/docscribe/types/rbs/provider.rbs
@@ -32,6 +32,14 @@ module Docscribe
 
         def build_env: (Array[String] dirs) -> ::RBS::Environment
 
+        def build_env_with_collection: (Array[String] all_dirs, Array[String] collection_dirs) -> ::RBS::Environment
+
+        def add_dirs_to_loader!: (::RBS::EnvironmentLoader loader, Array[String] all_dirs, Array[String] collection_dirs) -> void
+
+        def add_collection_gem_dirs: (::RBS::EnvironmentLoader loader, Pathname path, Array[String] stdlib) -> void
+
+        def stdlib_gem_names: -> Array[String]
+
         def definition_for: (container: String, scope: Symbol) -> (::RBS::Definition | nil)
 
         def parse_type_name: (String string) -> ::RBS::TypeName
@@ -40,7 +48,7 @@ module Docscribe
 
         def build_signature: (::RBS::Types::Function func) -> Types::MethodSignature
 
-        def build_param_types: (::RBS::Types::Function func) -> [ Hash[String, String], Array[String] ]
+        def build_param_types: (::RBS::Types::Function func) -> [Hash[String, String], Array[String]]
 
         def add_keywords!: (Hash[String, String] param_types, Hash[Symbol, ::RBS::Types::Function::Param] keywords) -> void
 

--- a/sig/lib/docscribe/types/rbs/provider.rbs
+++ b/sig/lib/docscribe/types/rbs/provider.rbs
@@ -39,7 +39,10 @@ module Docscribe
         def add_collection_gem_dirs: (::RBS::EnvironmentLoader loader, Pathname path, Array[String] stdlib) -> void
 
         def stdlib_gem_names: -> Array[String]
+
         def load_stdlib_libraries!: (::RBS::EnvironmentLoader loader) -> void
+
+        def add_stdlib_gem: (::RBS::EnvironmentLoader loader, untyped gem) -> void
 
         def definition_for: (container: String, scope: Symbol) -> (::RBS::Definition | nil)
 

--- a/sig/lib/docscribe/types/sorbet/base_provider.rbs
+++ b/sig/lib/docscribe/types/sorbet/base_provider.rbs
@@ -4,11 +4,13 @@ module Docscribe
       class BaseProvider
         @collapse_generics: bool
 
+        @collapse_object_generics: bool
+
         @index: Hash[ [ String, Symbol, Symbol ], Types::MethodSignature ]
 
         @warned: bool
 
-        def initialize: (?collapse_generics: bool) -> void
+        def initialize: (?collapse_generics: bool, ?collapse_object_generics: bool) -> void
 
         def signature_for: (container: String, scope: Symbol, name: (Symbol | String)) -> (Types::MethodSignature | nil)
 

--- a/sig/lib/docscribe/types/sorbet/rbi_provider.rbs
+++ b/sig/lib/docscribe/types/sorbet/rbi_provider.rbs
@@ -2,7 +2,7 @@ module Docscribe
   module Types
     module Sorbet
       class RBIProvider < BaseProvider
-        def initialize: (rbi_dirs: Array[String], ?collapse_generics: bool) -> void
+        def initialize: (rbi_dirs: Array[String], ?collapse_generics: bool, ?collapse_object_generics: bool) -> void
       end
     end
   end

--- a/sig/lib/docscribe/types/sorbet/source_provider.rbs
+++ b/sig/lib/docscribe/types/sorbet/source_provider.rbs
@@ -2,7 +2,7 @@ module Docscribe
   module Types
     module Sorbet
       class SourceProvider < BaseProvider
-        def initialize: (source: String, file: String, ?collapse_generics: bool) -> void
+        def initialize: (source: String, file: String, ?collapse_generics: bool, ?collapse_object_generics: bool) -> void
       end
     end
   end

--- a/spec/config/defaults_consistency_spec.rb
+++ b/spec/config/defaults_consistency_spec.rb
@@ -53,17 +53,19 @@ RSpec.describe Docscribe::Config do
   end
 
   describe 'rbs section' do
-    it 'has matching enabled and collapse_generics', :aggregate_failures do
+    it 'has matching enabled and collapse settings', :aggregate_failures do
       expect(yaml.dig('rbs', 'enabled')).to eq(default.dig('rbs', 'enabled'))
       expect(yaml.dig('rbs', 'collapse_generics')).to eq(default.dig('rbs', 'collapse_generics'))
+      expect(yaml.dig('rbs', 'collapse_object_generics')).to eq(default.dig('rbs', 'collapse_object_generics'))
       expect(yaml.dig('rbs', 'sig_dirs')).to match_array(default.dig('rbs', 'sig_dirs'))
     end
   end
 
   describe 'sorbet section' do
-    it 'has matching enabled and collapse_generics', :aggregate_failures do
+    it 'has matching enabled and collapse settings', :aggregate_failures do
       expect(yaml.dig('sorbet', 'enabled')).to eq(default.dig('sorbet', 'enabled'))
       expect(yaml.dig('sorbet', 'collapse_generics')).to eq(default.dig('sorbet', 'collapse_generics'))
+      expect(yaml.dig('sorbet', 'collapse_object_generics')).to eq(default.dig('sorbet', 'collapse_object_generics'))
       expect(yaml.dig('sorbet', 'rbi_dirs')).to match_array(default.dig('sorbet', 'rbi_dirs'))
     end
   end

--- a/spec/config/rbs_load_error_spec.rb
+++ b/spec/config/rbs_load_error_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Docscribe::Config do
   end
 
   describe 'build_rbs_provider with missing rbs gem' do
-    let(:config) { described_class.new({ 'rbs' => { 'enabled' => true } }) }
+    let(:config) { described_class.new('rbs' => { 'enabled' => true }) }
 
     it 'returns nil' do
       expect(config.rbs_provider).to be_nil
@@ -23,7 +23,7 @@ RSpec.describe Docscribe::Config do
   end
 
   describe 'build_core_rbs_provider with missing rbs gem' do
-    let(:config) { described_class.new({}) }
+    let(:config) { described_class.new }
 
     it 'returns nil without warning' do
       expect(config.core_rbs_provider).to be_nil

--- a/spec/config/rbs_ruby_version_spec.rb
+++ b/spec/config/rbs_ruby_version_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe Docscribe::Config do
     it 'returns nil on Ruby < 3.0' do
       stub_const('RUBY_VERSION', '2.7.8')
 
-      config = described_class.new({})
+      config = described_class.new
       expect(config.core_rbs_provider).to be_nil
     end
 
     it 'warns when Ruby < 3.0' do
       stub_const('RUBY_VERSION', '2.7.8')
 
-      config = described_class.new({})
+      config = described_class.new
       expect { config.core_rbs_provider }
         .to output(/RBS requires Ruby 3\.0\+/).to_stderr
     end

--- a/spec/docscribe/cli/banner_spec.rb
+++ b/spec/docscribe/cli/banner_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'docscribe/cli'
+
+CLI_DIR = File.expand_path('../../../lib/docscribe/cli', __dir__)
+EXCLUDE = %w[run.rb config_builder.rb formatters.rb].freeze
+
+RSpec.describe Docscribe::CLI do
+  include BannerSpecHelper
+
+  describe 'BANNER constant' do
+    Dir["#{CLI_DIR}/*.rb"].each do |file|
+      next if File.basename(file).start_with?('_') || EXCLUDE.include?(File.basename(file))
+
+      it "defines BANNER in #{File.basename(file)}" do
+        expect(File.read(file)).to match(/BANNER = <<~/)
+      end
+
+      it "has BANNER constant in #{File.basename(file)}" do
+        expect(Object.const_get(BannerSpecHelper.module_name(file))).to be_const_defined(:BANNER)
+      end
+    end
+  end
+end

--- a/spec/docscribe/cli/banner_spec.rb
+++ b/spec/docscribe/cli/banner_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Docscribe::CLI do
       end
 
       it "has BANNER constant in #{File.basename(file)}" do
+        require "docscribe/cli/#{File.basename(file, '.rb')}"
         expect(Object.const_get(BannerSpecHelper.module_name(file))).to be_const_defined(:BANNER)
       end
     end

--- a/spec/docscribe/cli/check_for_comments_spec.rb
+++ b/spec/docscribe/cli/check_for_comments_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'open3'
 require 'docscribe/cli'
+require 'docscribe/cli/check_for_comments'
 
 def resolve_config(raw, param_doc)
   instance_double(Docscribe::Config, raw: raw, param_documentation: param_doc)

--- a/spec/docscribe/cli/cli_spec.rb
+++ b/spec/docscribe/cli/cli_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Docscribe::CLI do
     RUBY
   end
 
-  let(:conf) { Docscribe::Config.new({ 'emit' => { 'return_tag' => false } }) }
+  let(:conf) { Docscribe::Config.new('emit' => { 'return_tag' => false }) }
 
   it 'reads from --stdin and outputs docs', :aggregate_failures do
     Dir.mktmpdir do |dir|

--- a/spec/docscribe/cli/config_builder_spec.rb
+++ b/spec/docscribe/cli/config_builder_spec.rb
@@ -96,7 +96,17 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
   end
 
   describe 'build' do
-    let(:base) { Docscribe::Config.new }
+    let(:base) { Docscribe::Config.new(config_path: '/tmp/.docscribe/test.yml') }
+
+    it 'preserves config_path from base without overrides' do
+      config = described_class.build(base, default_options)
+      expect(config.config_path).to eq('/tmp/.docscribe/test.yml')
+    end
+
+    it 'preserves config_path from base with overrides' do
+      config = described_class.build(base, default_options.merge(no_boilerplate: true))
+      expect(config.config_path).to eq('/tmp/.docscribe/test.yml')
+    end
 
     it 'sets emit flags when no_boilerplate is in options', :aggregate_failures do
       config = described_class.build(base, default_options.merge(no_boilerplate: true))

--- a/spec/docscribe/cli/config_builder_spec.rb
+++ b/spec/docscribe/cli/config_builder_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
   end
 
   describe 'build' do
-    let(:base) { Docscribe::Config.new({}) }
+    let(:base) { Docscribe::Config.new }
 
     it 'sets emit flags when no_boilerplate is in options', :aggregate_failures do
       config = described_class.build(base, default_options.merge(no_boilerplate: true))
@@ -124,7 +124,7 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
       require 'docscribe/types/rbs/collection_loader'
       allow(Docscribe::Types::RBS::CollectionLoader).to receive(:resolve).and_return(nil)
 
-      raw = Marshal.load(Marshal.dump(Docscribe::Config.new({}).raw))
+      raw = Marshal.load(Marshal.dump(Docscribe::Config.new.raw))
       expect { described_class.apply_rbs_collection(raw) }
         .to output(/rbs_collection\.lock\.yaml not found/).to_stderr
     end

--- a/spec/docscribe/cli/generate_spec.rb
+++ b/spec/docscribe/cli/generate_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'docscribe/cli'
+require 'docscribe/cli/generate'
 require 'tmpdir'
 require 'fileutils'
 

--- a/spec/docscribe/cli/run_spec.rb
+++ b/spec/docscribe/cli/run_spec.rb
@@ -3,6 +3,7 @@
 require 'open3'
 require 'tmpdir'
 require 'docscribe/cli'
+require 'docscribe/server'
 
 RSpec.describe Docscribe::CLI::Run do
   subject(:result) { Open3.capture3('ruby', exe, *args, chdir: dir) }
@@ -390,6 +391,21 @@ RSpec.describe Docscribe::CLI::Run do
 
     it 'exits 0' do
       expect(result[2].exitstatus).to eq(0)
+    end
+  end
+
+  describe '.wait_for_server' do
+    it 'raises when server does not become ready' do
+      allow(Docscribe::Server).to receive(:running?).and_return(false)
+
+      expect do
+        described_class.send(:wait_for_server, timeout: 0.1)
+      end.to raise_error(RuntimeError, /server failed to start/)
+    end
+
+    it 'returns when server becomes ready' do
+      allow(Docscribe::Server).to receive(:running?).and_return(false, true)
+      expect { described_class.send(:wait_for_server, timeout: 1) }.not_to raise_error
     end
   end
 end

--- a/spec/docscribe/cli/run_spec.rb
+++ b/spec/docscribe/cli/run_spec.rb
@@ -394,18 +394,11 @@ RSpec.describe Docscribe::CLI::Run do
     end
   end
 
-  describe '.wait_for_server' do
-    it 'raises when server does not become ready' do
-      allow(Docscribe::Server).to receive(:running?).and_return(false)
-
-      expect do
-        described_class.send(:wait_for_server, timeout: 0.1)
-      end.to raise_error(RuntimeError, /server failed to start/)
-    end
-
-    it 'returns when server becomes ready' do
-      allow(Docscribe::Server).to receive(:running?).and_return(false, true)
-      expect { described_class.send(:wait_for_server, timeout: 1) }.not_to raise_error
+  describe '.ensure_server_running!' do
+    it 'delegates to Docscribe::Server.ensure_running!' do
+      allow(Docscribe::Server).to receive(:ensure_running!)
+      described_class.send(:ensure_server_running!, config_path: nil)
+      expect(Docscribe::Server).to have_received(:ensure_running!).with(config_path: nil)
     end
   end
 end

--- a/spec/docscribe/cli/server_spec.rb
+++ b/spec/docscribe/cli/server_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'tmpdir'
+require 'securerandom'
+require 'rbconfig'
+require 'docscribe/cli'
+
+RSpec.describe Docscribe::CLI do
+  describe 'server subcommand' do
+    describe 'without arguments' do
+      let(:dir) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(dir) }
+
+      it 'prints usage to stderr' do
+        _out, err, st = Open3.capture3(RbConfig.ruby, exe, 'server', chdir: dir)
+        aggregate_failures do
+          expect(err).to include('Usage: docscribe server <command>')
+          expect(st.exitstatus).to eq(1)
+        end
+      end
+    end
+
+    describe 'status' do
+      let(:dir) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(dir) }
+
+      it 'reports not running initially' do
+        _out, err, st = Open3.capture3(RbConfig.ruby, exe, 'server', 'status', chdir: dir)
+        aggregate_failures do
+          expect(err).to include('not running')
+          expect(st.exitstatus).to eq(0)
+        end
+      end
+    end
+
+    describe 'start' do
+      let(:dir) { Dir.mktmpdir }
+      let(:server_cmd) { ->(*args) { Open3.capture3(RbConfig.ruby, exe, 'server', *args, chdir: dir) } }
+
+      after do
+        server_cmd.call('stop')
+        FileUtils.remove_entry(dir)
+      end
+
+      it 'starts the server and reports success' do
+        _out, err, st = server_cmd.call('start')
+        aggregate_failures do
+          expect(err).to match(/started/)
+          expect(st.exitstatus).to eq(0)
+        end
+      end
+
+      it 'makes the server accessible for status' do
+        _out, err, st = server_cmd.call('start') && server_cmd.call('status')
+        aggregate_failures do
+          expect(err).to include('running')
+          expect(st.exitstatus).to eq(0)
+        end
+      end
+
+      it 'reports already running on second start' do
+        _out, err, st = [server_cmd.call('start'), server_cmd.call('start')][1]
+        aggregate_failures do
+          expect(err).to include('already running')
+          expect(st.exitstatus).to eq(0)
+        end
+      end
+    end
+
+    describe 'stop' do
+      let(:dir) { Dir.mktmpdir }
+      let(:server_cmd) { ->(*args) { Open3.capture3(RbConfig.ruby, exe, 'server', *args, chdir: dir) } }
+
+      after do
+        server_cmd.call('stop')
+        FileUtils.remove_entry(dir)
+      end
+
+      it 'reports not running when no server' do
+        _out, err, st = server_cmd.call('stop')
+        aggregate_failures do
+          expect(err).to include('not running')
+          expect(st.exitstatus).to eq(0)
+        end
+      end
+
+      it 'stops a running server' do
+        _out, stop_err, stop_st = server_cmd.call('start') && server_cmd.call('stop')
+        aggregate_failures do
+          expect(stop_err).to include('stopped')
+          expect(stop_st.exitstatus).to eq(0)
+        end
+      end
+    end
+
+    describe 'start/stop lifecycle' do
+      let(:dir) { Dir.mktmpdir }
+      let(:server_status) do
+        _, err, = Open3.capture3(RbConfig.ruby, exe, 'server', 'status', chdir: dir)
+        err
+      end
+
+      after { FileUtils.remove_entry(dir) }
+
+      it 'starts as not running' do
+        expect(server_status).to include('not running')
+      end
+
+      it 'becomes running after start' do
+        Open3.capture3(RbConfig.ruby, exe, 'server', 'start', chdir: dir)
+        expect(server_status).to include('running')
+      end
+
+      it 'returns to not running after stop' do
+        Open3.capture3(RbConfig.ruby, exe, 'server', 'start', chdir: dir)
+        Open3.capture3(RbConfig.ruby, exe, 'server', 'stop', chdir: dir)
+        expect(server_status).to include('not running')
+      end
+    end
+  end
+
+  describe '--server flag' do
+    let(:dir) { Dir.mktmpdir }
+    let(:file) { "#{dir}/#{SecureRandom.hex(8)}.rb" }
+    let(:server_cmd) { ->(*args) { Open3.capture3(RbConfig.ruby, exe, 'server', *args, chdir: dir) } }
+
+    before do
+      File.write(file, <<~RUBY)
+        def hello
+          puts 'world'
+        end
+      RUBY
+      _, start_err, start_st = server_cmd.call('start')
+      raise "Failed to start server: #{start_err}" unless start_st&.exitstatus == 0
+    end
+
+    after do
+      server_cmd.call('stop')
+      FileUtils.remove_entry(dir)
+    end
+
+    it 'returns findings from the server' do
+      out, _err, st = Open3.capture3(RbConfig.ruby, exe, '--server', 'check', file, chdir: dir)
+      aggregate_failures do
+        expect(out).to include('Would update:')
+        expect(st.exitstatus).to eq(1)
+      end
+    end
+
+    context 'with --autocorrect' do
+      it 'applies fixes via the server' do
+        _out, _err, st = Open3.capture3(RbConfig.ruby, exe, '--server', '-a', file, chdir: dir)
+        aggregate_failures do
+          expect(st.exitstatus).to eq(0)
+          expect(File.read(file)).to include('@return')
+        end
+      end
+    end
+
+    context 'with --quiet' do
+      it 'does not print change details' do
+        out, _err, _st = Open3.capture3(RbConfig.ruby, exe, '--server', '--quiet', 'check', file, chdir: dir)
+        aggregate_failures do
+          expect(out).to include('Would update:')
+          expect(out).not_to include('missing docs')
+        end
+      end
+    end
+  end
+end

--- a/spec/docscribe/cli/server_spec.rb
+++ b/spec/docscribe/cli/server_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe Docscribe::CLI do
       end
     end
 
+    describe 'with --config / -C' do
+      let(:dir) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(dir) }
+
+      it 'status -C works' do
+        _out, err, st = Open3.capture3(RbConfig.ruby, exe, 'server', 'status', '-C', 'nonexistent.yml', chdir: dir)
+        aggregate_failures do
+          expect(err).to include('not running')
+          expect(st.exitstatus).to eq(0)
+        end
+      end
+    end
+
     describe 'start' do
       let(:dir) { Dir.mktmpdir }
       let(:server_cmd) { ->(*args) { Open3.capture3(RbConfig.ruby, exe, 'server', *args, chdir: dir) } }

--- a/spec/docscribe/cli/server_spec.rb
+++ b/spec/docscribe/cli/server_spec.rb
@@ -184,4 +184,31 @@ RSpec.describe Docscribe::CLI do
       end
     end
   end
+
+  describe 'docscribe-client thin executable' do
+    let(:dir) { Dir.mktmpdir }
+    let(:thin_exe) { File.expand_path('exe/docscribe-client') }
+    let(:file) { "#{dir}/test.rb" }
+
+    before do
+      File.write(file, <<~RUBY)
+        def hello
+          puts 'world'
+        end
+      RUBY
+      Open3.capture3(RbConfig.ruby, exe, 'server', 'start', chdir: dir)
+    end
+
+    after do
+      Open3.capture3(RbConfig.ruby, exe, 'server', 'stop', chdir: dir)
+      FileUtils.remove_entry(dir)
+    end
+
+    it 'checks a file and returns JSON', :aggregate_failures do
+      out, _, st = Open3.capture3(RbConfig.ruby, thin_exe, '--check', file, chdir: dir)
+      result = JSON.parse(out)
+      expect(result.dig('result', 'status')).to eq('fail')
+      expect(st.exitstatus).to eq(0)
+    end
+  end
 end

--- a/spec/docscribe/cli/sigs_spec.rb
+++ b/spec/docscribe/cli/sigs_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'open3'
 require 'docscribe/cli'
+require 'docscribe/cli/sigs'
 
 RSpec.describe Docscribe::CLI::Sigs do
   describe 'helper methods' do

--- a/spec/docscribe/cli/update_types_spec.rb
+++ b/spec/docscribe/cli/update_types_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'open3'
 require 'docscribe/cli'
+require 'docscribe/cli/update_types'
 
 DEFAULT_OPTS = Docscribe::CLI::Options::DEFAULT.dup
 

--- a/spec/docscribe/config_spec.rb
+++ b/spec/docscribe/config_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Docscribe::Config do
   describe '#process_method?' do
     describe 'falls back to DEFAULT filter scopes/visibilities when filter keys are missing' do
-      subject(:conf) { described_class.new({}) }
+      subject(:conf) { described_class.new }
 
       it { expect(conf.process_method?(container: 'A', scope: :instance, visibility: :public, name: :foo)).to be(true) }
       it { expect(conf.process_method?(container: 'A', scope: :class, visibility: :private, name: :bar)).to be(true) }

--- a/spec/docscribe/inline_rewriter/doc_builder_spec.rb
+++ b/spec/docscribe/inline_rewriter/doc_builder_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
 require 'docscribe/inline_rewriter/doc_builder'
 
 RSpec.describe Docscribe::InlineRewriter::DocBuilder do
@@ -226,6 +227,79 @@ RSpec.describe Docscribe::InlineRewriter::DocBuilder do
 
     it 'has exactly one @param tag entry (multiline ins + new kind)' do
       expect(out.scan(/^\s*# @param/).size).to eq(2)
+    end
+  end
+
+  describe 'does not duplicate conditional rescue @return in aggressive keep_descriptions mode' do
+    subject(:out) { inline(code, config: config, strategy: :aggressive) }
+
+    let(:config) { Docscribe::Config.new('keep_descriptions' => true, 'emit' => { 'rescue_conditional_returns' => true }) }
+
+    let(:code) { <<~RUBY }
+      class A
+        # @return [Integer] if RuntimeError
+        def foo
+          1
+        rescue RuntimeError
+          0
+        end
+      end
+    RUBY
+
+    it 'does not duplicate conditional @return [Integer] if RuntimeError' do
+      expect(out.scan(/^(\s*# @return \[Integer\] if RuntimeError\s*$)/).size).to eq(1)
+    end
+  end
+
+  describe 'rescue body returning a parameter with known type' do
+    subject(:out) { inline(code, config: conf, strategy: :aggressive) }
+
+    let(:conf) { Docscribe::Config.new('emit' => { 'rescue_conditional_returns' => true }) }
+
+    let(:code) { <<~RUBY }
+      class A
+        def count_lines(text = '')
+          text.lines.size
+        rescue StandardError
+          text
+        end
+      end
+    RUBY
+
+    it 'uses String, not Object, for rescue @return (param type from default)' do
+      expect(out).to include('# @return [String] if StandardError')
+    end
+  end
+
+  describe 'explicit receiver call in rescue resolved via signature_provider', :rbs do
+    subject(:out) { inline_with_rbs(code: code, rbs: rbs) }
+
+    let(:rbs) do
+      <<~RBS
+        class Demo
+          def fallback: -> String
+        end
+
+        class Foo
+          def bar: (Demo demo) -> String
+        end
+      RBS
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Foo
+          def bar(demo)
+            "ok"
+          rescue StandardError
+            demo.fallback
+          end
+        end
+      RUBY
+    end
+
+    it 'resolves rescue return type from explicit receiver call via RBS' do
+      expect(out).to include('# @return [String] if StandardError')
     end
   end
 end

--- a/spec/docscribe/lru_cache_spec.rb
+++ b/spec/docscribe/lru_cache_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'docscribe/lru_cache'
+
+RSpec.describe Docscribe::LRUCache do
+  subject(:cache) { described_class.new(max_size) }
+
+  let(:max_size) { 3 }
+
+  describe '#[] and #[]=' do
+    it 'stores and retrieves values' do
+      cache[:a] = 1
+      expect(cache[:a]).to eq(1)
+    end
+
+    it 'returns nil for missing keys' do
+      expect(cache[:missing]).to be_nil
+    end
+
+    describe 'access order promotion' do
+      before do
+        cache[:a] = 1
+        cache[:b] = 2
+        cache[:c] = 3
+        cache[:a] # promote :a
+        cache[:d] = 4
+      end
+
+      it 'evicts least recently used after read' do
+        expect(cache[:b]).to be_nil
+      end
+
+      it 'keeps :a after promotion' do
+        expect(cache[:a]).to eq(1)
+      end
+
+      it 'keeps :c as recently used' do
+        expect(cache[:c]).to eq(3)
+      end
+
+      it 'stores the new entry' do
+        expect(cache[:d]).to eq(4)
+      end
+    end
+  end
+
+  describe '#size' do
+    it 'tracks number of entries' do
+      cache[:a] = 1
+      cache[:b] = 2
+      expect(cache.size).to eq(2)
+    end
+
+    it 'does not exceed max_size' do
+      max_size.times { |i| cache[i] = i }
+      cache[:extra] = 99
+      expect(cache.size).to eq(max_size)
+    end
+  end
+
+  describe '#clear' do
+    it 'empties the cache' do
+      cache[:a] = 1
+      cache.clear
+      expect(cache).to be_empty
+    end
+  end
+
+  describe '#empty?' do
+    it 'returns true when empty' do
+      expect(cache).to be_empty
+    end
+
+    it 'returns false with entries' do
+      cache[:a] = 1
+      expect(cache).not_to be_empty
+    end
+  end
+
+  describe 'eviction policy' do
+    before do
+      cache[:a] = 1
+      cache[:b] = 2
+      cache[:c] = 3
+    end
+
+    it 'evicts least recently used entries' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:b]).to be_nil
+    end
+
+    it 'retains :a after access' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:a]).to eq(1)
+    end
+
+    it 'retains :c as survivor' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:c]).to eq(3)
+    end
+
+    it 'stores the new entry' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:d]).to eq(4)
+    end
+
+    describe 'reinsertion on write' do
+      before do
+        cache[:a] = 10 # should move :a to front
+        cache[:d] = 4
+      end
+
+      it 'evicts the previous LRU' do
+        expect(cache[:b]).to be_nil
+      end
+
+      it 'keeps updated value' do
+        expect(cache[:a]).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Docscribe::Server do
   include ServerWireHelper
 
   describe '.socket_path' do
-    it 'returns a path under /tmp' do
-      expect(described_class.socket_path).to match(%r{\A/tmp/docscribe-})
+    it 'returns a path under tmpdir' do
+      expect(described_class.socket_path).to match(%r{\A(?:#{Regexp.escape(Dir.tmpdir)}|/tmp)/docscribe-})
     end
 
     it 'includes an MD5 of the working directory' do
@@ -151,7 +151,7 @@ RSpec.describe Docscribe::Server do
     after { FileUtils.rm_rf(dir) }
 
     it 'returns false when socket does not exist' do
-      allow(described_class).to receive(:socket_path).and_return('/tmp/nonexistent.sock')
+      allow(described_class).to receive(:socket_path).and_return("#{Dir.tmpdir}/nonexistent.sock")
       expect(described_class.running?).to be false
     end
 
@@ -243,6 +243,12 @@ RSpec.describe Docscribe::Server do
     describe '#shutdown' do
       it 'returns nil when server is unreachable' do
         expect(client.shutdown).to be_nil
+      end
+    end
+
+    describe '#ping' do
+      it 'returns nil when server is unreachable' do
+        expect(client.ping).to be_nil
       end
     end
 
@@ -351,6 +357,36 @@ RSpec.describe Docscribe::Server do
         client.shutdown
         sleep 0.3
         expect(File.exist?(socket_path)).to be false
+      end
+    end
+
+    describe 'ping request' do
+      def ping_response
+        client.ping
+      end
+
+      it 'responds to ping' do
+        expect(ping_response).not_to be_nil
+      end
+
+      it 'returns version' do
+        expect(ping_response.dig('result', 'version')).to eq(Docscribe::VERSION)
+      end
+
+      it 'returns pid' do
+        expect(ping_response.dig('result', 'pid')).to eq(Process.pid)
+      end
+
+      it 'returns socket_path' do
+        expect(ping_response.dig('result', 'socket_path')).to eq(socket_path)
+      end
+
+      it 'returns started_at as an ISO8601 string' do
+        expect(ping_response.dig('result', 'started_at')).to be_a(String)
+      end
+
+      it 'returns uptime as an integer' do
+        expect(ping_response.dig('result', 'uptime')).to be_a(Integer)
       end
     end
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -17,6 +17,130 @@ RSpec.describe Docscribe::Server do
       hash_segment = Digest::MD5.hexdigest(Dir.pwd)
       expect(described_class.socket_path).to include(hash_segment)
     end
+
+    describe 'with config_path' do
+      around { |ex| Dir.mktmpdir { |t| Dir.chdir(t, &ex) } }
+
+      it 'resolves relative path to absolute before hashing' do
+        rel = described_class.socket_path('some.yml')
+        abs = described_class.socket_path("#{Dir.pwd}/some.yml")
+        expect(rel).to eq(abs)
+      end
+
+      it 'includes mtime as float' do
+        File.write('cfg.yml', '')
+        expect(described_class.socket_path('cfg.yml')).to match(/\.sock\z/)
+      end
+    end
+  end
+
+  describe '.wait_for_ready' do
+    it 'returns when server becomes ready' do
+      allow(described_class).to receive(:running?).and_return(true)
+      expect { described_class.wait_for_ready(timeout: 5) }.not_to raise_error
+    end
+
+    it 'raises on timeout when raise_on_timeout is true' do
+      allow(described_class).to receive(:running?).and_return(false)
+
+      expect do
+        described_class.wait_for_ready(timeout: 0.01, raise_on_timeout: true)
+      end.to raise_error(RuntimeError, 'Docscribe: server failed to start')
+    end
+
+    it 'does not raise on timeout when raise_on_timeout is false' do
+      allow(described_class).to receive(:running?).and_return(false)
+
+      expect do
+        described_class.wait_for_ready(timeout: 0.01, raise_on_timeout: false)
+      end.not_to raise_error
+    end
+  end
+
+  describe '.process_alive?' do
+    it 'returns true when process exists' do
+      expect(described_class.send(:process_alive?, Process.pid)).to be true
+    end
+
+    it 'returns false when process is gone' do
+      pid = spawn('true')
+      Process.wait(pid)
+      expect(described_class.send(:process_alive?, pid)).to be false
+    end
+  end
+
+  describe '.ensure_running!' do
+    before do
+      allow(described_class).to receive(:running?).and_return(false)
+      allow(described_class).to receive(:wait_for_ready)
+      allow(Process).to receive(:fork).and_return(12_345)
+      allow(Process).to receive(:detach)
+    end
+
+    it 'returns early when server is already running' do
+      allow(described_class).to receive(:running?).and_return(true)
+      expect { described_class.ensure_running! }.not_to raise_error
+    end
+
+    it 'raises when fork is unavailable' do
+      allow(Process).to receive(:respond_to?).with(:fork).and_return(false)
+      expect { described_class.ensure_running! }.to raise_error(/fork not supported/)
+    end
+
+    it 'calls fork' do
+      described_class.ensure_running!
+      expect(Process).to have_received(:fork)
+    end
+
+    it 'calls wait_for_ready after fork' do
+      described_class.ensure_running!
+      expect(described_class).to have_received(:wait_for_ready)
+    end
+  end
+
+  describe '.handle_stale_socket?' do
+    let(:dir) { Dir.mktmpdir }
+    let(:sock) { "#{dir}/test.sock" }
+    let(:pidfile) { "#{dir}/test.pid" }
+    let(:setup_alive) do
+      allow(described_class).to receive(:read_pid).and_return(Process.pid)
+      allow(described_class).to receive_messages(socket_path: sock, pid_path: pidfile)
+      File.write(sock, '')
+    end
+    let(:setup_dead) do
+      pid = spawn('true')
+      Process.wait(pid)
+      allow(described_class).to receive(:read_pid).and_return(pid)
+      allow(described_class).to receive_messages(socket_path: sock, pid_path: pidfile)
+      pid
+    end
+
+    after { FileUtils.rm_rf(dir) }
+
+    it 'returns false when PID is alive' do
+      setup_alive
+      expect(described_class.send(:handle_stale_socket?, nil)).to be false
+    end
+
+    it 'does not clean up socket when PID is alive' do
+      setup_alive
+      described_class.send(:handle_stale_socket?, nil)
+      expect(File.exist?(sock)).to be true
+    end
+
+    it 'cleans up socket when PID is dead' do
+      _pid = setup_dead
+      File.write(sock, '')
+      described_class.send(:handle_stale_socket?, nil)
+      expect(File.exist?(sock)).to be false
+    end
+
+    it 'cleans up pidfile when PID is dead' do
+      pid = setup_dead
+      File.write(pidfile, pid.to_s)
+      described_class.send(:handle_stale_socket?, nil)
+      expect(File.exist?(pidfile)).to be false
+    end
   end
 
   describe '.running?' do

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -383,6 +383,18 @@ RSpec.describe Docscribe::Server do
         end
       end
 
+      def override_hash
+        {
+          'no_boilerplate' => true,
+          'include' => [],
+          'exclude' => [],
+          'include_file' => [],
+          'exclude_file' => [],
+          'sig_dirs' => [],
+          'rbi_dirs' => []
+        }
+      end
+
       it 'caches across repeated calls' do
         with_cache_dir do |daemon, test_file|
           orig = daemon.send(:rewrite_file, test_file, :safe)
@@ -394,7 +406,44 @@ RSpec.describe Docscribe::Server do
       it 'clears cache when cli overrides change' do
         with_cache_dir do |daemon, test_file|
           daemon.send(:rewrite_file, test_file, :safe)
-          daemon.send(:apply_cli_overrides, Docscribe::CLI::Options::DEFAULT.merge(no_boilerplate: true).transform_keys(&:to_s))
+          daemon.send(:apply_cli_overrides, override_hash)
+          expect(daemon.instance_variable_get(:@file_cache)).to be_empty
+        end
+      end
+
+      it 'sets effective_config when overrides applied' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.send(:apply_cli_overrides, override_hash)
+          expect(daemon.instance_variable_get(:@effective_config)).not_to be_nil
+        end
+      end
+
+      it 'records applied_overrides' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.send(:apply_cli_overrides, override_hash)
+          expect(daemon.instance_variable_get(:@applied_overrides)).to eq(override_hash)
+        end
+      end
+
+      it 'unsets effective_config when overrides become nil' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.send(:apply_cli_overrides, override_hash)
+          daemon.send(:apply_cli_overrides, nil)
+          expect(daemon.instance_variable_get(:@effective_config)).to be_nil
+        end
+      end
+
+      it 'unsets applied_overrides when overrides become nil' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.send(:apply_cli_overrides, override_hash)
+          daemon.send(:apply_cli_overrides, nil)
+          expect(daemon.instance_variable_get(:@applied_overrides)).to be_nil
+        end
+      end
+
+      it 'clears cache when overrides become nil' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.send(:apply_cli_overrides, override_hash) && daemon.send(:apply_cli_overrides, nil)
           expect(daemon.instance_variable_get(:@file_cache)).to be_empty
         end
       end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Docscribe::Server do
     end
 
     it 'includes an MD5 of the working directory' do
-      hash_segment = Digest::MD5.hexdigest(Dir.pwd)
+      seed = +Dir.pwd
+      seed << ":#{described_class.send(:env_hash)}"
+      hash_segment = Digest::MD5.hexdigest(seed)
       expect(described_class.socket_path).to include(hash_segment)
     end
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -390,6 +390,14 @@ RSpec.describe Docscribe::Server do
           expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
         end
       end
+
+      it 'clears cache when cli overrides change' do
+        with_cache_dir do |daemon, test_file|
+          daemon.send(:rewrite_file, test_file, :safe)
+          daemon.send(:apply_cli_overrides, Docscribe::CLI::Options::DEFAULT.merge(no_boilerplate: true).transform_keys(&:to_s))
+          expect(daemon.instance_variable_get(:@file_cache)).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'docscribe/server'
+
+RSpec.describe Docscribe::Server do
+  include SuppressErrorHelper
+  include CleanFileHelper
+  include ServerWireHelper
+
+  describe '.socket_path' do
+    it 'returns a path under /tmp' do
+      expect(described_class.socket_path).to match(%r{\A/tmp/docscribe-})
+    end
+
+    it 'includes an MD5 of the working directory' do
+      hash_segment = Digest::MD5.hexdigest(Dir.pwd)
+      expect(described_class.socket_path).to include(hash_segment)
+    end
+  end
+
+  describe '.running?' do
+    let(:dir) { Dir.mktmpdir }
+    let(:sock) { "#{dir}/test.sock" }
+
+    after { FileUtils.rm_rf(dir) }
+
+    it 'returns false when socket does not exist' do
+      allow(described_class).to receive(:socket_path).and_return('/tmp/nonexistent.sock')
+      expect(described_class.running?).to be false
+    end
+
+    it 'returns false when socket file is stale (not a real socket)' do
+      allow(described_class).to receive_messages(socket_path: sock, pid_path: "#{dir}/test.pid")
+      File.write(sock, '')
+      expect(described_class.running?).to be false
+    end
+
+    it 'cleans up stale socket file' do
+      allow(described_class).to receive_messages(socket_path: sock, pid_path: "#{dir}/test.pid")
+      File.write(sock, '')
+      described_class.running?
+      expect(File.exist?(sock)).to be false
+    end
+  end
+
+  describe Docscribe::Server::Protocol do
+    describe '.build_request' do
+      subject(:request) { described_class.build_request('check', file: 'test.rb') }
+
+      it 'includes jsonrpc version' do
+        expect(request[:jsonrpc]).to eq('2.0')
+      end
+
+      it 'includes an id' do
+        aggregate_failures do
+          expect(request[:id]).to be_a(String)
+          expect(request[:id].length).to eq(16)
+        end
+      end
+
+      it 'includes the method name' do
+        expect(request[:method]).to eq('check')
+      end
+
+      it 'includes params' do
+        expect(request[:params]).to eq(file: 'test.rb')
+      end
+    end
+
+    describe '.parse_response' do
+      it 'parses valid JSON' do
+        result = described_class.parse_response('{"id":1,"result":{"status":"ok"}}')
+        aggregate_failures do
+          expect(result['id']).to eq(1)
+          expect(result['result']['status']).to eq('ok')
+        end
+      end
+
+      it 'returns nil for invalid JSON' do
+        expect(described_class.parse_response('not json')).to be_nil
+      end
+
+      it 'returns nil for empty string' do
+        expect(described_class.parse_response('')).to be_nil
+      end
+    end
+
+    describe '.serialize' do
+      it 'produces JSON with trailing newline' do
+        result = described_class.serialize({ a: 1 })
+        expect(result).to eq("{\"a\":1}\n")
+      end
+    end
+  end
+
+  describe Docscribe::Server::Client do
+    subject(:client) { described_class.new(socket_path) }
+
+    let(:socket_path) { "#{Dir.mktmpdir}/test.sock" }
+
+    after do
+      FileUtils.rm_rf(File.dirname(socket_path))
+    end
+
+    describe '#check' do
+      it 'returns nil when server is unreachable' do
+        expect(client.check(file: 'test.rb')).to be_nil
+      end
+    end
+
+    describe '#fix' do
+      it 'returns nil when server is unreachable' do
+        expect(client.fix(file: 'test.rb')).to be_nil
+      end
+    end
+
+    describe '#shutdown' do
+      it 'returns nil when server is unreachable' do
+        expect(client.shutdown).to be_nil
+      end
+    end
+
+    describe 'wire format' do
+      it 'sends request with single trailing newline', :aggregate_failures do
+        raw_data = with_unix_server { |s| described_class.new(s).check(file: 'test.rb') }
+        expect(raw_data.count("\n")).to eq(1)
+        expect(raw_data).to end_with("\n")
+      end
+    end
+  end
+
+  describe Docscribe::Server::Daemon do
+    let!(:socket_path) { "#{Dir.mktmpdir}/docscribe-test.sock" }
+    let!(:test_file) do
+      path = "#{File.dirname(socket_path)}/test.rb"
+      File.write(path, <<~RUBY)
+        def hello
+          puts 'world'
+        end
+      RUBY
+      path
+    end
+
+    let!(:daemon) { described_class.new(socket_path: socket_path, idle_timeout: 60) }
+    let!(:daemon_thread) { Thread.new { daemon.start } }
+    let(:client) { Docscribe::Server::Client.new(socket_path) }
+
+    before { sleep 0.5 }
+
+    after do
+      suppress_error { Docscribe::Server::Client.new(socket_path).shutdown }
+      suppress_error { daemon_thread.join(3) }
+      FileUtils.remove_entry(File.dirname(socket_path))
+    end
+
+    describe '#start' do
+      it 'creates a socket file' do
+        aggregate_failures do
+          expect(File.exist?(socket_path)).to be true
+          expect(File.exist?("#{socket_path}.pid")).to be true
+        end
+      end
+    end
+
+    describe 'check request' do
+      it 'returns ok for a file with no issues' do
+        response = client.check(file: create_clean_file(socket_path))
+        aggregate_failures do
+          expect(response).not_to be_nil
+          expect(response['result'].slice('status', 'changed')).to eq('status' => 'ok', 'changed' => false)
+        end
+      end
+
+      it 'returns fail for a file needing updates' do
+        response = client.check(file: test_file)
+        aggregate_failures do
+          expect(response).not_to be_nil
+          expect(response['result']['status']).to eq('fail')
+        end
+      end
+
+      it 'returns error for a nonexistent file' do
+        response = client.check(file: '/nonexistent.rb')
+        aggregate_failures do
+          expect(response).not_to be_nil
+          expect(response.dig('error', 'message')).to include('File not found')
+        end
+      end
+
+      it 'defaults to safe strategy when not specified', :aggregate_failures do
+        response = client.check(file: test_file)
+        expect(response).not_to be_nil
+        expect(response['error']).to be_nil
+        expect(response['result']).to have_key('status')
+      end
+    end
+
+    describe 'fix request' do
+      it 'returns success status' do
+        response = client.fix(file: test_file)
+        aggregate_failures do
+          expect(response).not_to be_nil
+          expect(response['result']['status']).to eq('ok')
+        end
+      end
+
+      it 'writes corrected content to the file' do
+        before_fix = File.read(test_file)
+        client.fix(file: test_file)
+        after_fix = File.read(test_file)
+        expect([after_fix != before_fix, after_fix.include?('@return')]).to eq([true, true])
+      end
+    end
+
+    describe 'shutdown request' do
+      it 'responds to shutdown request' do
+        response = client.shutdown
+        aggregate_failures do
+          expect(response).not_to be_nil
+          expect(response['result']['status']).to eq('shutting_down')
+        end
+      end
+
+      it 'removes the socket after shutdown' do
+        client.shutdown
+        sleep 0.3
+        expect(File.exist?(socket_path)).to be false
+      end
+    end
+  end
+end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -71,14 +71,15 @@ RSpec.describe Docscribe::Server do
 
   describe '.ensure_running!' do
     before do
-      allow(described_class).to receive(:running?).and_return(false)
-      allow(described_class).to receive(:wait_for_ready)
+      allow(described_class).to receive(:wait_for_ready).and_return(false)
       allow(Process).to receive(:fork).and_return(12_345)
       allow(Process).to receive(:detach)
     end
 
     it 'returns early when server is already running' do
-      allow(described_class).to receive(:running?).and_return(true)
+      allow(described_class).to receive(:wait_for_ready)
+        .with(config_path: nil, timeout: 0, raise_on_timeout: false)
+        .and_return(true)
       expect { described_class.ensure_running! }.not_to raise_error
     end
 
@@ -94,7 +95,7 @@ RSpec.describe Docscribe::Server do
 
     it 'calls wait_for_ready after fork' do
       described_class.ensure_running!
-      expect(described_class).to have_received(:wait_for_ready)
+      expect(described_class).to have_received(:wait_for_ready).at_least(:once)
     end
   end
 
@@ -350,6 +351,44 @@ RSpec.describe Docscribe::Server do
         client.shutdown
         sleep 0.3
         expect(File.exist?(socket_path)).to be false
+      end
+    end
+
+    describe 'idle timeout' do
+      def with_idle_daemon(timeout)
+        Dir.mktmpdir do |dir|
+          sock = "#{dir}/idle.sock"
+          daemon = described_class.new(socket_path: sock, idle_timeout: timeout)
+          thread = Thread.new { daemon.start }
+          sleep 0.1 until File.exist?(sock)
+          yield daemon, thread
+        end
+      end
+
+      it 'stops the daemon when idle timeout expires' do
+        with_idle_daemon(0.3) do |_daemon, thread|
+          expect(thread.join(2)).to be(thread)
+        end
+      end
+    end
+
+    describe 'file cache' do
+      def with_cache_dir
+        Dir.mktmpdir do |dir|
+          test_file = "#{dir}/test.rb"
+          daemon = described_class.new(socket_path: "#{dir}/cache.sock", idle_timeout: 60)
+          File.write(test_file, "def foo\nend")
+          daemon.send(:load_dependencies)
+          yield daemon, test_file
+        end
+      end
+
+      it 'caches across repeated calls' do
+        with_cache_dir do |daemon, test_file|
+          orig = daemon.send(:rewrite_file, test_file, :safe)
+          allow(Docscribe::InlineRewriter).to receive(:rewrite_with_report) { raise 'called twice' }
+          expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
+        end
       end
     end
   end

--- a/spec/docscribe/types/rbs/provider_spec.rb
+++ b/spec/docscribe/types/rbs/provider_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+RSpec.describe 'Docscribe::Types::RBS::Provider' do
+  before do
+    skip_unless_rbs_available!
+    require 'docscribe/types/rbs/provider'
+  end
+
+  let(:provider) { Docscribe::Types::RBS::Provider.new(sig_dirs: []) }
+
+  describe '#definition_for' do
+    before { provider.signature_for(container: 'Integer', scope: :instance, name: :to_s) }
+
+    it 'strips YARD-style generic params (Array<String> -> Array)' do
+      result = provider.send(:definition_for, container: 'Array<String>', scope: :instance)
+      expect(result).not_to be_nil
+    end
+
+    it 'strips RBS-style generic params (Array[String] -> Array)' do
+      result = provider.send(:definition_for, container: 'Array[String]', scope: :instance)
+      expect(result).not_to be_nil
+    end
+
+    it 'returns nil for unknown type names' do
+      result = provider.send(:definition_for, container: 'NonExistentFooBar', scope: :instance)
+      expect(result).to be_nil
+    end
+
+    it 'works for plain class names' do
+      result = provider.send(:definition_for, container: 'Integer', scope: :instance)
+      expect(result).not_to be_nil
+    end
+
+    it 'handles nested generic params (Array[Array[String]] -> Array)' do
+      result = provider.send(:definition_for, container: 'Array[Array[String]]', scope: :instance)
+      expect(result).not_to be_nil
+    end
+
+    it 'handles singleton scope' do
+      result = provider.send(:definition_for, container: 'String', scope: :class)
+      expect(result).not_to be_nil
+    end
+
+    it 'returns nil for unknown singleton scope' do
+      result = provider.send(:definition_for, container: 'NonExistentFooBar', scope: :class)
+      expect(result).to be_nil
+    end
+  end
+
+  describe '#signature_for' do
+    context 'with a custom RBS class' do
+      let(:root) { Dir.mktmpdir }
+      let(:sig_dir) { File.join(root, 'sig') }
+      let(:provider) { Docscribe::Types::RBS::Provider.new(sig_dirs: [sig_dir]) }
+
+      before do
+        FileUtils.mkdir_p(sig_dir)
+        File.write(File.join(sig_dir, 'demo.rbs'), <<~RBS)
+          class Demo
+            def foo: (Array[String] items, Hash[Symbol, Integer] options) -> Array[Integer]
+          end
+        RBS
+      end
+
+      after { FileUtils.rm_rf(root) }
+
+      it 'resolves a signature for a known class', :aggregate_failures do
+        sig = provider.signature_for(container: 'Demo', scope: :instance, name: :foo)
+        expect(sig).not_to be_nil
+        expect(sig.param_types['items']).to eq('Array<String>')
+        expect(sig.param_types['options']).to eq('Hash<Symbol, Integer>')
+      end
+
+      it 'resolves signature with YARD-style generic container name' do
+        sig = provider.signature_for(container: 'Demo<String>', scope: :instance, name: :foo)
+        expect(sig).not_to be_nil
+      end
+
+      it 'returns nil for unknown methods on known class' do
+        sig = provider.signature_for(container: 'Demo', scope: :instance, name: :bar)
+        expect(sig).to be_nil
+      end
+
+      it 'returns nil for unknown container' do
+        sig = provider.signature_for(container: 'NonExistent', scope: :instance, name: :foo)
+        expect(sig).to be_nil
+      end
+    end
+
+    context 'with core stdlib types' do
+      let(:provider) { Docscribe::Types::RBS::Provider.new(sig_dirs: []) }
+
+      it 'resolves Array#map' do
+        sig = provider.signature_for(container: 'Array', scope: :instance, name: :map)
+        expect(sig).not_to be_nil
+      end
+
+      it 'resolves Array#map with YARD-style generic container' do
+        sig = provider.signature_for(container: 'Array<String>', scope: :instance, name: :map)
+        expect(sig).not_to be_nil
+      end
+
+      it 'resolves Array#map with RBS-style generic container' do
+        sig = provider.signature_for(container: 'Array[Integer]', scope: :instance, name: :map)
+        expect(sig).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/docscribe/types/rbs/type_formatter_spec.rb
+++ b/spec/docscribe/types/rbs/type_formatter_spec.rb
@@ -118,5 +118,51 @@ RSpec.describe 'Docscribe::Types::RBS::TypeFormatter' do
         expect(yard(type)).to eq('Integer')
       end
     end
+
+    describe 'collapse_object_generics option' do
+      let(:object_type) { RBS::Types::Bases::Any.new(location: nil) }
+      let(:string_type) { RBS::Types::ClassInstance.new(name: type_name('::String'), args: [], location: nil) }
+      let(:integer_type) { RBS::Types::ClassInstance.new(name: type_name('::Integer'), args: [], location: nil) }
+
+      def yard_cog(type, collapse_object_generics: false)
+        Docscribe::Types::RBS::TypeFormatter.to_yard(type, collapse_object_generics: collapse_object_generics)
+      end
+
+      it 'keeps Array<Object> when collapse_object_generics is false (default)' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [object_type], location: nil)
+        expect(yard_cog(type)).to eq('Array<Object>')
+      end
+
+      it 'collapses Array<Object> to Array when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [object_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Array')
+      end
+
+      it 'keeps Array<String> when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [string_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Array<String>')
+      end
+
+      it 'keeps Array<Integer> when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [integer_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Array<Integer>')
+      end
+
+      it 'collapses Hash<Object, Object> to Hash when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Hash'), args: [object_type, object_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Hash')
+      end
+
+      it 'keeps Hash<String, Integer> when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Hash'), args: [string_type, integer_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Hash<String, Integer>')
+      end
+
+      it 'collapse_generics overrides collapse_object_generics' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [string_type], location: nil)
+        result = Docscribe::Types::RBS::TypeFormatter.to_yard(type, collapse_generics: true, collapse_object_generics: false)
+        expect(result).to eq('Array')
+      end
+    end
   end
 end

--- a/spec/infer/rescue_implicit_self_spec.rb
+++ b/spec/infer/rescue_implicit_self_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+
+RSpec.describe Docscribe::Infer do
+  before { skip_unless_rbs_available! }
+
+  describe 'implicit self call in rescue branch resolved via RBS container' do
+    subject(:out) { inline_with_rbs(code: code, rbs: rbs) }
+
+    let(:rbs) do
+      <<~RBS
+        class Demo
+          def fallback: -> String
+        end
+      RBS
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          def foo
+            "ok"
+          rescue StandardError
+            fallback
+          end
+        end
+      RUBY
+    end
+
+    it 'resolves return type of main body from implicit self rescue method' do
+      expect(out).to include('# @return [String]')
+    end
+
+    it 'tags rescue branch with the resolved RBS type' do
+      expect(out).to include('# @return [String] if StandardError')
+    end
+  end
+
+  describe 'implicit self call without rescue resolved via RBS container' do
+    subject(:out) { inline_with_rbs(code: code, rbs: rbs) }
+
+    let(:rbs) do
+      <<~RBS
+        class Demo
+          def helper: -> Integer
+        end
+      RBS
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          def foo
+            helper
+          end
+        end
+      RUBY
+    end
+
+    it 'resolves normal return type from implicit self call via RBS' do
+      expect(out).to include('# @return [Integer]')
+    end
+  end
+
+  describe 'implicit self call in multi-rescue resolved via RBS container' do
+    subject(:out) { inline_with_rbs(code: code, rbs: rbs) }
+
+    let(:rbs) do
+      <<~RBS
+        class Demo
+          def fallback_a: -> Integer
+          def fallback_b: -> String
+        end
+      RBS
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          def foo
+            "main"
+          rescue ArgumentError
+            fallback_a
+          rescue KeyError
+            fallback_b
+          end
+        end
+      RUBY
+    end
+
+    it 'resolves main body return type for multi-rescue method' do
+      expect(out).to include('# @return [String]')
+    end
+
+    it 'resolves first rescue branch type from implicit self call' do
+      expect(out).to include('# @return [Integer] if ArgumentError')
+    end
+
+    it 'resolves second rescue branch type from implicit self call' do
+      expect(out).to include('# @return [String] if KeyError')
+    end
+  end
+end

--- a/spec/integrations/sorbet/collapse_object_generics_spec.rb
+++ b/spec/integrations/sorbet/collapse_object_generics_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe Docscribe::InlineRewriter do
+  before { skip_unless_sorbet_bridge_available! }
+
+  let(:code) do
+    <<~RUBY
+      class Demo
+        extend T::Sig
+
+        sig { returns(T::Array[T.untyped]) }
+        def foo
+          []
+        end
+      end
+    RUBY
+  end
+
+  let(:strategy) { :safe }
+
+  describe 'when collapse_object_generics is false (default)' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_object_generics' => false }
+                   ))
+    end
+
+    it 'keeps Array<Object> in @return tag', :aggregate_failures do
+      expect(out).to include('# @return [Array<Object>]')
+      expect(out).not_to include('# @return [Array]')
+    end
+  end
+
+  describe 'when collapse_object_generics is true' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_object_generics' => true }
+                   ))
+    end
+
+    it 'collapses Array<Object> to Array in @return tag', :aggregate_failures do
+      expect(out).to include('# @return [Array]')
+      expect(out).not_to include('# @return [Array<Object>]')
+    end
+  end
+
+  describe 'when collapsible generics contain non-Object types' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_object_generics' => true }
+                   ))
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          extend T::Sig
+
+          sig { returns(T::Array[Integer]) }
+          def foo
+            []
+          end
+        end
+      RUBY
+    end
+
+    it 'keeps Array<Integer> when collapse_object_generics is true', :aggregate_failures do
+      expect(out).to include('# @return [Array<Integer>]')
+      expect(out).not_to include('# @return [Array]')
+    end
+  end
+
+  describe 'when collapse_generics overrides collapse_object_generics' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_generics' => true, 'collapse_object_generics' => false }
+                   ))
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          extend T::Sig
+
+          sig { returns(T::Array[Integer]) }
+          def foo
+            []
+          end
+        end
+      RUBY
+    end
+
+    it 'collapse_generics collapses even non-Object generics', :aggregate_failures do
+      expect(out).to include('# @return [Array]')
+      expect(out).not_to include('# @return [Array<Integer>]')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ module InlineHelper
   # @param [Symbol] strategy rewrite strategy (:safe or :aggressive)
   # @param [String] file file with Ruby source code
   # @return [String] rewritten source code
-  def inline(code, config: Docscribe::Config.new({}), strategy: :safe, file: nil)
+  def inline(code, config: Docscribe::Config.new, strategy: :safe, file: nil)
     Docscribe::InlineRewriter.insert_comments(code, strategy: strategy, config: config, file: file)
   end
 end

--- a/spec/support/banner_spec_helper.rb
+++ b/spec/support/banner_spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module BannerSpecHelper
+  NAME_MAP = {
+    'server' => 'ServerCmd'
+  }.freeze
+
+  def self.module_name(file)
+    bn = File.basename(file, '.rb')
+    mapped = NAME_MAP[bn] || bn.split('_').map(&:capitalize).join
+    "Docscribe::CLI::#{mapped}"
+  end
+end

--- a/spec/support/clean_file_helper.rb
+++ b/spec/support/clean_file_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CleanFileHelper
+  def create_clean_file(socket_path)
+    path = "#{File.dirname(socket_path)}/clean.rb"
+    File.write(path, "# Documented method\n# @return [String]\ndef greet\n  'hello'\nend\n")
+    path
+  end
+end

--- a/spec/support/rbs_helper.rb
+++ b/spec/support/rbs_helper.rb
@@ -10,7 +10,7 @@ module RbsHelper
   def inline_with_sorbet(code, strategy: :safe, config_overrides: {})
     skip_unless_sorbet_bridge_available!
     raw = { 'sorbet' => { 'enabled' => true } }.merge(config_overrides)
-    inline(code, strategy: strategy, config: Docscribe::Config.new(raw))
+    inline(code, strategy: strategy, config: Docscribe::Config.new(**raw))
   end
 
   # Rewrite +code+ with both Sorbet RBI and optionally RBS signature files.
@@ -33,7 +33,7 @@ module RbsHelper
       File.write(File.join(rbi_dir, 'demo.rbi'), rbi)
       raw = { 'sorbet' => { 'enabled' => true, 'rbi_dirs' => [rbi_dir] } }.merge(config_overrides)
       raw.merge!(rbs_config(dir, dir_names[:sig], rbs)) if rbs
-      inline(code, config: Docscribe::Config.new(raw))
+      inline(code, config: Docscribe::Config.new(**raw))
     end
   end
 
@@ -56,7 +56,7 @@ module RbsHelper
 
       inline(
         code,
-        config: Docscribe::Config.new(config.merge('rbs' => { 'enabled' => true, 'sig_dirs' => [sig_dir] }))
+        config: Docscribe::Config.new(**config, 'rbs' => { 'enabled' => true, 'sig_dirs' => [sig_dir] })
       )
     end
   end

--- a/spec/support/server_wire_helper.rb
+++ b/spec/support/server_wire_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ServerWireHelper
+  def with_unix_server
+    Dir.mktmpdir do |dir|
+      server = UNIXServer.new("#{dir}/test.sock")
+      raw_data = +''
+      server_thread = Thread.new { accept_read(server, raw_data) }
+      yield "#{dir}/test.sock"
+      server_thread.join
+      server.close
+      raw_data
+    end
+  end
+
+  private
+
+  def accept_read(server, raw_data)
+    c = server.accept
+    raw_data.replace(c.read)
+    c.close
+  end
+end

--- a/spec/support/suppress_error_helper.rb
+++ b/spec/support/suppress_error_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SuppressErrorHelper
+  def suppress_error
+    yield
+  rescue StandardError
+    nil
+  end
+end


### PR DESCRIPTION
## Summary

v1.5.1 adds a persistent server/daemon mode that loads the Ruby runtime once and serves multiple check/fix requests over a Unix socket (JSON-RPC 2.0), dramatically reducing per-invocation overhead.

### Highlights

- **Server mode** — `docscribe server start|status|stop`, `--server` flag, `docscribe-client` thin executable
- **Idle timeout** — daemon auto-shuts down after 300s of inactivity
- **File cache** — per-file results cached by mtime, bounded by LRUCache (1000)
- **Env invalidation** — socket path includes mtime of `Gemfile.lock` + `rbs_collection.lock.yaml`; gem/RBS changes spawn a new daemon automatically
- **ConfigBuilder fix** — `config_path` preserved across CLI overrides; file cache cleared when overrides change
- **Sorbet generics** — `rbs.collapse_object_generics` option
- **Stability** — fork guard, cleanup race fixes, unified startup

### Files

- `lib/docscribe/server.rb` — daemon logic, socket lifecycle, file cache
- `lib/docscribe/lru_cache.rb` — bounded LRU cache (max 1000 entries)
- `lib/docscribe/cli/server.rb` — `docscribe server` subcommand
- `exe/docscribe-client` — standalone thin client
- `lib/docscribe/cli/config_builder.rb` — config_path fix
- `lib/docscribe/cli/run.rb` — `--server` flag, filtered paths
- `sig/` — RBS declarations for all new classes/methods

### Checklist

- [x] RSpec — 1019 examples, 0 failures, 3 pending (pre-existing)
- [x] RuboCop — 0 offenses (208 files)
- [x] Steep — no type errors