### PR TITLE
[1.5.1] Fix idle timeout, add sorbet generics, thin client, file cache

### DIFF
--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require 'socket'
+require 'json'
+require 'securerandom'
+require 'digest/md5'
+
+SOCKET_DIR = '/tmp'
+
+def socket_path(config_path = nil)
+  hash = Digest::MD5.hexdigest(Dir.pwd)
+  if config_path
+    resolved = File.expand_path(config_path)
+    mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+    cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
+    "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
+  else
+    "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+  end
+end
+
+def send_request(sock, method, params = {})
+  socket = UNIXSocket.new(sock)
+  req = build_request(method, params)
+  socket.write("#{JSON.generate(req)}\n")
+  socket.close_write
+  line = socket.gets
+  line ? JSON.parse(line) : nil
+rescue Errno::ECONNREFUSED, Errno::ENOENT
+  nil
+ensure
+  socket&.close
+end
+
+def build_request(method, params = {})
+  { jsonrpc: '2.0', id: SecureRandom.uuid, method: method, params: params }
+end
+
+config_path = nil
+mode = nil
+file = nil
+
+OptionParser.new do |opts|
+  opts.on('-C', '--config <path>', 'Config file path') { |v| config_path = v }
+  opts.on('--check <file>', 'Check a file') do |v|
+    mode = :check
+    file = v
+  end
+  opts.on('--fix <file>', 'Fix a file') do |v|
+    mode = :fix
+    file = v
+  end
+  opts.on('--shutdown', 'Shutdown the server') { mode = :shutdown }
+  opts.on('--status', 'Show server status') { mode = :status }
+end.parse!
+
+sock = socket_path(config_path)
+
+case mode
+when :check
+  result = send_request(sock, 'check', file: file, strategy: :safe)
+  puts JSON.generate(result || { error: 'Connection failed' })
+when :fix
+  result = send_request(sock, 'fix', file: file, strategy: :safe)
+  puts JSON.generate(result || { error: 'Connection failed' })
+when :shutdown
+  result = send_request(sock, 'shutdown')
+  puts JSON.generate(result || { error: 'Connection failed' })
+when :status
+  alive = begin
+    File.exist?(sock) &&
+      UNIXSocket.new(sock).close && true
+  rescue StandardError
+    false
+  end
+  puts JSON.generate(alive ? { status: 'running', socket: sock } : { status: 'not_running' })
+else
+  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status"
+  exit 1
+end

--- a/lib/docscribe/cli.rb
+++ b/lib/docscribe/cli.rb
@@ -1,28 +1,12 @@
 # frozen_string_literal: true
 
-require 'docscribe/cli/init'
-require 'docscribe/cli/generate'
 require 'docscribe/cli/options'
 require 'docscribe/cli/run'
-require 'docscribe/cli/sigs'
-require 'docscribe/cli/rbs_gen'
-require 'docscribe/cli/update_types'
-require 'docscribe/cli/check_for_comments'
-require 'docscribe/cli/server'
 
 module Docscribe
   # CLI entry point and command dispatch.
   module CLI
     class << self
-      # Main CLI entry point.
-      #
-      # Dispatches:
-      # - `docscribe init ...`     to the config-template generator
-      # - `docscribe generate ...` to the plugin skeleton generator
-      # - all other commands to the main option parser and runner
-      #
-      # @param [Array<String>] argv raw command-line arguments
-      # @return [Integer] process exit code
       def run(argv)
         argv = argv.dup
         return dispatch_subcommand(argv) if subcommand?(argv.first)
@@ -32,35 +16,28 @@ module Docscribe
       end
 
       COMMANDS = {
-        'init' => Docscribe::CLI::Init,
-        'generate' => Docscribe::CLI::Generate,
-        'sigs' => Docscribe::CLI::Sigs,
-        'rbs' => Docscribe::CLI::RbsGen,
-        'update_types' => Docscribe::CLI::UpdateTypes,
-        'check_for_comments' => Docscribe::CLI::CheckForComments,
-        'server' => Docscribe::CLI::ServerCmd
+        'init' => :Init,
+        'generate' => :Generate,
+        'sigs' => :Sigs,
+        'rbs' => :RbsGen,
+        'update_types' => :UpdateTypes,
+        'check_for_comments' => :CheckForComments,
+        'server' => :ServerCmd
       }.freeze
 
       private
 
-      # Subcommand
-      #
-      # @private
-      # @param [String?] cmd potential subcommand name
-      # @return [Boolean]
       def subcommand?(cmd)
         COMMANDS.key?(cmd)
       end
 
-      # Dispatch subcommand
-      #
-      # @private
-      # @param [Array<String>] argv raw command-line arguments
-      # @return [Integer]
       def dispatch_subcommand(argv)
         cmd = argv.shift
-        mod = COMMANDS[cmd]
-        mod ? mod.run(argv) : 0
+        const_name = COMMANDS[cmd]
+        return 0 unless const_name
+
+        require "docscribe/cli/#{cmd == 'rbs' ? 'rbs_gen' : cmd}"
+        Docscribe::CLI.const_get(const_name).run(argv)
       end
     end
   end

--- a/lib/docscribe/cli.rb
+++ b/lib/docscribe/cli.rb
@@ -7,6 +7,8 @@ module Docscribe
   # CLI entry point and command dispatch.
   module CLI
     class << self
+      # @param [Array<String>] argv
+      # @return [Integer]
       def run(argv)
         argv = argv.dup
         return dispatch_subcommand(argv) if subcommand?(argv.first)
@@ -27,10 +29,16 @@ module Docscribe
 
       private
 
+      # @private
+      # @param [String?] cmd
+      # @return [Boolean]
       def subcommand?(cmd)
         COMMANDS.key?(cmd)
       end
 
+      # @private
+      # @param [Array<String>] argv
+      # @return [Integer]
       def dispatch_subcommand(argv)
         cmd = argv.shift
         const_name = COMMANDS[cmd]

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -4,7 +4,6 @@ require 'pathname'
 
 require 'docscribe/cli/config_builder'
 require 'docscribe/cli/formatters'
-require 'docscribe/inline_rewriter'
 
 module Docscribe
   module CLI
@@ -35,6 +34,14 @@ module Docscribe
           total: 0,
           processed: 0
         }.freeze
+
+        CLI_OVERRIDE_KEYS = %i[
+          keep_descriptions no_boilerplate
+          include exclude include_file exclude_file
+          rbs rbs_collection sig_dirs
+          sorbet rbi_dirs
+        ].freeze
+
         # Run Docscribe for files or STDIN using the selected mode and strategy.
         #
         # Modes:
@@ -52,6 +59,7 @@ module Docscribe
         def run(options:, argv:)
           return run_via_server(options: options, argv: argv) if options[:server]
 
+          require 'docscribe/inline_rewriter'
           conf = build_config(options)
 
           return run_stdin(options: options, conf: conf) if options[:mode] == :stdin
@@ -62,19 +70,9 @@ module Docscribe
           run_files(options: options, conf: conf, paths: paths)
         end
 
-        # Run via the background server daemon.
-        #
-        # Each file is processed by the server, which keeps the Ruby runtime loaded
-        # between requests.
-        #
-        # @param [Docscribe::CLI::Formatters::opts] options parsed CLI options
-        # @param [Array<String>] argv remaining path arguments
-        # @raise [RuntimeError]
-        # @return [Integer] if RuntimeError
-        # @return [Integer] if RuntimeError
         def run_via_server(options:, argv:)
           require 'docscribe/server'
-          conf = build_config(options)
+          conf = build_light_config(options)
           ensure_server_running!(config_path: conf.config_path)
           client = Docscribe::Server::Client.new(config_path: conf.config_path)
           paths = filtered_paths(argv, conf)
@@ -104,15 +102,16 @@ module Docscribe
           run_exit_code(options, state)
         end
 
-        # Load and build the effective config from CLI options.
-        #
-        # @param [Docscribe::CLI::Formatters::opts] options parsed CLI options
-        # @return [Docscribe::Config] effective config with plugins loaded
         def build_config(options)
           conf = Docscribe::Config.load(options[:config])
           conf = Docscribe::CLI::ConfigBuilder.build(conf, options)
           conf.load_plugins!
           conf
+        end
+
+        def build_light_config(options)
+          conf = Docscribe::Config.load(options[:config])
+          Docscribe::CLI::ConfigBuilder.build(conf, options)
         end
 
         # Rewrite code from STDIN using the selected strategy and print the
@@ -200,16 +199,13 @@ module Docscribe
                                  display_path: display_path, options: options, state: state)
         end
 
-        # Send a request to the server for a file.
-        #
-        # @param [Docscribe::Server::Client] client server client
-        # @param [String] path file path
-        # @param [Docscribe::CLI::Formatters::opts] options CLI options
-        # @return [Hash<String, Object>, nil] server response
         def send_server_request(client, path, options)
-          method_name = options[:mode] == :write ? 'fix' : 'check'
+          method_name = options[:mode] == :write ? :fix : :check
           strategy = options[:strategy].to_s
-          client.send(method_name, file: path, strategy: strategy)
+          cli_overrides = extract_cli_overrides(options)
+          params = { file: path, strategy: strategy }
+          params[:cli_overrides] = cli_overrides unless cli_overrides.empty?
+          client.send(method_name, **params)
         end
 
         # Record a server error in the shared state and print an indicator.
@@ -384,6 +380,16 @@ module Docscribe
           finalize_run(options, state)
 
           run_exit_code(options, state)
+        end
+
+        def extract_cli_overrides(options)
+          overrides = options.slice(*CLI_OVERRIDE_KEYS)
+          overrides.each_with_object({}) do |(k, v), h|
+            next if v.nil? || v == false
+            next if v.is_a?(Array) && v.empty?
+
+            h[k.to_s] = v
+          end
         end
 
         private

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -70,6 +70,11 @@ module Docscribe
           run_files(options: options, conf: conf, paths: paths)
         end
 
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @param [Array<String>] argv
+        # @raise [RuntimeError]
+        # @return [Integer]
+        # @return [Integer] if RuntimeError
         def run_via_server(options:, argv:)
           require 'docscribe/server'
           conf = build_light_config(options)
@@ -102,6 +107,8 @@ module Docscribe
           run_exit_code(options, state)
         end
 
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Docscribe::Config]
         def build_config(options)
           conf = Docscribe::Config.load(options[:config])
           conf = Docscribe::CLI::ConfigBuilder.build(conf, options)
@@ -109,6 +116,8 @@ module Docscribe
           conf
         end
 
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Docscribe::Config]
         def build_light_config(options)
           conf = Docscribe::Config.load(options[:config])
           Docscribe::CLI::ConfigBuilder.build(conf, options)
@@ -199,13 +208,19 @@ module Docscribe
                                  display_path: display_path, options: options, state: state)
         end
 
+        # @param [Docscribe::Server::Client] client
+        # @param [String] path
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Hash<String, Object>, nil]
         def send_server_request(client, path, options)
           method_name = options[:mode] == :write ? :fix : :check
           strategy = options[:strategy].to_s
           cli_overrides = extract_cli_overrides(options)
-          params = { file: path, strategy: strategy }
-          params[:cli_overrides] = cli_overrides unless cli_overrides.empty?
-          client.send(method_name, **params)
+          if cli_overrides.empty?
+            client.send(method_name, file: path, strategy: strategy)
+          else
+            client.send(method_name, file: path, strategy: strategy, cli_overrides: cli_overrides)
+          end
         end
 
         # Record a server error in the shared state and print an indicator.
@@ -382,14 +397,18 @@ module Docscribe
           run_exit_code(options, state)
         end
 
+        # @param [Docscribe::CLI::Formatters::opts] options
+        # @return [Hash<String, Object>]
         def extract_cli_overrides(options)
           overrides = options.slice(*CLI_OVERRIDE_KEYS)
-          overrides.each_with_object({}) do |(k, v), h|
+          acc = {} #: Hash[String, untyped]
+          overrides.each do |k, v|
             next if v.nil? || v == false
             next if v.is_a?(Array) && v.empty?
 
-            h[k.to_s] = v
+            acc[k.to_s] = v
           end
+          acc
         end
 
         private

--- a/lib/docscribe/config/defaults.rb
+++ b/lib/docscribe/config/defaults.rb
@@ -70,7 +70,8 @@ module Docscribe
       'sorbet' => {
         'enabled' => false,
         'rbi_dirs' => ['sorbet/rbi', 'rbi'],
-        'collapse_generics' => false
+        'collapse_generics' => false,
+        'collapse_object_generics' => false
       },
       'keep_descriptions' => false,
       'skip_anonymous_block_params' => false,

--- a/lib/docscribe/config/sorbet.rb
+++ b/lib/docscribe/config/sorbet.rb
@@ -47,7 +47,8 @@ module Docscribe
       Docscribe::Types::Sorbet::SourceProvider.new(
         source: source,
         file: file,
-        collapse_generics: sorbet_collapse_generics?
+        collapse_generics: sorbet_collapse_generics?,
+        collapse_object_generics: sorbet_collapse_object_generics?
       )
     rescue LoadError
       nil
@@ -74,10 +75,9 @@ module Docscribe
 
       @sorbet_rbi_provider ||= begin
         require 'docscribe/types/sorbet/rbi_provider'
-        Docscribe::Types::Sorbet::RBIProvider.new(
-          rbi_dirs: sorbet_rbi_dirs,
-          collapse_generics: sorbet_collapse_generics?
-        )
+        Docscribe::Types::Sorbet::RBIProvider.new(rbi_dirs: sorbet_rbi_dirs,
+                                                  collapse_generics: sorbet_collapse_generics?,
+                                                  collapse_object_generics: sorbet_collapse_object_generics?)
       rescue LoadError
         nil
       end
@@ -105,6 +105,15 @@ module Docscribe
     # @return [Boolean]
     def sorbet_collapse_generics?
       fetch_bool(%w[sorbet collapse_generics], rbs_collapse_generics?)
+    end
+
+    # Whether to collapse Object-typed generics in Sorbet types.
+    #
+    # Falls back to the RBS setting when Sorbet-specific config is not present.
+    #
+    # @return [Boolean]
+    def sorbet_collapse_object_generics?
+      fetch_bool(%w[sorbet collapse_object_generics], rbs_collapse_object_generics?)
     end
   end
 end

--- a/lib/docscribe/config/template.rb
+++ b/lib/docscribe/config/template.rb
@@ -98,6 +98,7 @@ module Docscribe
           enabled: false
           rbi_dirs: ["sorbet/rbi", "rbi"]
           collapse_generics: false
+          collapse_object_generics: false
 
         # Preserve existing @param/@return descriptions in aggressive mode
         keep_descriptions: false

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -453,7 +453,7 @@ module Docscribe
       # @param [Object] file path to file
       # @param [Object] strategy rewrite strategy
       # @return [Array] original source and rewrite result
-      def rewrite_file(file, strategy) # rubocop:disable Metrics/MethodLength
+      def rewrite_file(file, strategy)
         key = [file, strategy]
         mtime = File.mtime(file)
         hit = @file_cache[key]

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -19,37 +19,44 @@ module Docscribe
     IDLE_TIMEOUT = 300
 
     class << self
-      # Start the server daemon and wait for it to become ready.
+      # Start the server daemon if not running.
       #
-      # @param [String?] config_path optional config path for socket/pid lookup
+      # @param [String?] config_path optional config file path
       # @param [Boolean] daemonize redirect stdin/stdout/stderr to /dev/null
       # @param [Integer] timeout max seconds to wait for readiness
       # @raise [StandardError]
       # @return [void]
       def ensure_running!(config_path: nil, daemonize: false, timeout: 5)
-        return if running?(config_path)
+        return if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
         raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
 
         lock_path = "#{socket_path(config_path)}.lock"
         File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
           lock.flock(File::LOCK_EX)
-          next if running?(config_path)
+          next if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
 
           start_daemon_process(config_path: config_path, daemonize: daemonize)
         end
         wait_for_ready(config_path: config_path, timeout: timeout)
       end
 
+      # Start the server daemon and wait for it to become ready.
+      #
+      # @param [String?] config_path optional config path for socket/pid lookup
+      # @param [Integer] timeout max seconds to wait for readiness
+      # @param [Boolean] raise_on_timeout
+      # @raise [StandardError]
+      # @return [Boolean]
       def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true)
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         loop do
-          return if running?(config_path)
+          return true if running?(config_path)
 
           if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
             raise('Docscribe: server failed to start') if raise_on_timeout
 
             warn('Docscribe server failed to start within timeout')
-            return
+            return false
           end
 
           sleep 0.1
@@ -67,7 +74,7 @@ module Docscribe
       # @raise [Errno::ENOENT]
       # @raise [Errno::ENOTSOCK]
       # @raise [StandardError]
-      # @return [Boolean]
+      # @return [Boolean] if StandardError
       # @return [Boolean] if Errno::ECONNREFUSED
       # @return [Boolean] if Errno::ENOENT, Errno::ENOTSOCK
       # @return [Boolean] if StandardError
@@ -87,7 +94,6 @@ module Docscribe
       # Handle ECONNREFUSED: check if the pid process is alive.
       # Cleans up only if the process is dead.
       #
-      # @private
       # @param [String?] config_path
       # @return [Boolean] false (not running)
       def handle_stale_socket?(config_path)
@@ -98,10 +104,9 @@ module Docscribe
         false
       end
 
-      # @private
       # @param [Integer] pid
       # @raise [Errno::ESRCH]
-      # @return [Boolean]
+      # @return [Boolean] if Errno::ESRCH
       # @return [Boolean] if Errno::ESRCH
       def process_alive?(pid)
         Process.kill(0, pid)
@@ -112,7 +117,7 @@ module Docscribe
 
       # @param [String?] config_path
       # @raise [StandardError]
-      # @return [Integer?]
+      # @return [Integer?] if StandardError
       # @return [nil] if StandardError
       def read_pid(config_path = nil)
         File.read(pid_path(config_path)).to_i if File.exist?(pid_path(config_path))
@@ -121,7 +126,7 @@ module Docscribe
       end
 
       # Remove stale socket and pid files.
-      # @private
+      #
       # @param [String?] config_path
       # @return [void]
       def clean_socket_files(config_path)
@@ -157,6 +162,9 @@ module Docscribe
 
       public :read_pid, :pid_path, :socket_path
 
+      # @param [String?] config_path
+      # @param [Boolean] daemonize
+      # @return [void]
       def start_daemon_process(config_path:, daemonize:)
         warn 'Docscribe: starting server...'
         pid = Process.fork do # steep:ignore NoMethod
@@ -223,18 +231,20 @@ module Docscribe
       #
       # @param [Object] file path to file to check
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
+      # @param [Hash] rest
       # @return [Object] response hash or nil if server unreachable
-      def check(file:, strategy: :safe)
-        request('check', file: file, strategy: strategy)
+      def check(file:, strategy: :safe, **rest)
+        request('check', file: file, strategy: strategy, **rest)
       end
 
       # Send a fix request to the server.
       #
       # @param [Object] file path to file to fix
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
+      # @param [Hash] rest
       # @return [Object] response hash or nil if server unreachable
-      def fix(file:, strategy: :safe)
-        request('fix', file: file, strategy: strategy)
+      def fix(file:, strategy: :safe, **rest)
+        request('fix', file: file, strategy: strategy, **rest)
       end
 
       # Send a shutdown request to the server.
@@ -285,7 +295,7 @@ module Docscribe
       # @param [nil] socket_path custom socket path
       # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
       # @param [nil] config_path custom config path
-      # @return [nil]
+      # @return [Hash]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
@@ -332,6 +342,8 @@ module Docscribe
         File.chmod(0o600, @socket_path)
       end
 
+      # @private
+      # @return [Object]
       def write_pid
         File.write("#{@socket_path}.pid", Process.pid)
       end
@@ -407,6 +419,11 @@ module Docscribe
         end
       end
 
+      # @private
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] params
+      # @return [Object]
       def handle_check(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -418,6 +435,11 @@ module Docscribe
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
       end
 
+      # @private
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] params
+      # @return [Object]
       def handle_fix(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -430,6 +452,9 @@ module Docscribe
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
       end
 
+      # @private
+      # @param [Object] overrides
+      # @return [Object]
       def apply_cli_overrides(overrides)
         return if overrides.nil? || overrides.empty?
         return if @applied_overrides == overrides
@@ -441,6 +466,11 @@ module Docscribe
         @applied_overrides = overrides
       end
 
+      # @private
+      # @param [Object] file
+      # @param [Object] strategy
+      # @raise [StandardError]
+      # @return [Array]
       def rewrite_file(file, strategy)
         config = @effective_config || @config or raise 'Docscribe: config not loaded'
         key = [file, strategy]
@@ -472,12 +502,18 @@ module Docscribe
       # @param [Object] client connected client socket
       # @param [Object] id request ID
       # @param [Object] result result data
-      # @return [nil]
+      # @return [Object]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }
         client.write(Protocol.serialize(response))
       end
 
+      # @private
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] code
+      # @param [Object] message
+      # @return [Object]
       def send_error(client, id, code, message)
         response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
         client.write(Protocol.serialize(response))

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -30,23 +30,16 @@ module Docscribe
         return if running?(config_path)
         raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
 
-        warn 'Docscribe: starting server...'
-        pid = Process.fork do # steep:ignore NoMethod
-          [$stdin, $stdout].each { _1.reopen(File::NULL) }
-          $stderr.reopen(File::NULL) if daemonize
-          Daemon.new(config_path: config_path).start
+        lock_path = "#{socket_path(config_path)}.lock"
+        File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
+          lock.flock(File::LOCK_EX)
+          next if running?(config_path)
+
+          start_daemon_process(config_path: config_path, daemonize: daemonize)
         end
-        Process.detach(pid)
         wait_for_ready(config_path: config_path, timeout: timeout)
       end
 
-      # Wait for the server to accept connections.
-      #
-      # @param [String?] config_path optional config path for socket/pid lookup
-      # @param [Integer] timeout max seconds to wait
-      # @param [Boolean] raise_on_timeout raise vs warn on timeout
-      # @raise [StandardError]
-      # @return [void]
       def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true)
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         loop do
@@ -90,8 +83,6 @@ module Docscribe
       rescue StandardError
         false
       end
-
-      private
 
       # Handle ECONNREFUSED: check if the pid process is alive.
       # Cleans up only if the process is dead.
@@ -164,9 +155,17 @@ module Docscribe
         end
       end
 
-      public :read_pid
-      public :pid_path
-      public :socket_path
+      public :read_pid, :pid_path, :socket_path
+
+      def start_daemon_process(config_path:, daemonize:)
+        warn 'Docscribe: starting server...'
+        pid = Process.fork do # steep:ignore NoMethod
+          [$stdin, $stdout].each { _1.reopen(File::NULL) }
+          $stderr.reopen(File::NULL) if daemonize
+          Daemon.new(config_path: config_path).start
+        end
+        Process.detach(pid)
+      end
     end
 
     # JSON-line protocol helpers.
@@ -333,10 +332,6 @@ module Docscribe
         File.chmod(0o600, @socket_path)
       end
 
-      # Write PID file so clients can find the server process.
-      #
-      # @private
-      # @return [Object]
       def write_pid
         File.write("#{@socket_path}.pid", Process.pid)
       end
@@ -412,55 +407,50 @@ module Docscribe
         end
       end
 
-      # Handle a check request: read file, run rewriter, return results.
-      #
-      # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] params request parameters
-      # @return [Object]
       def handle_check(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
         return send_error(client, id, -32_602, "File not found: #{file}") unless file && File.file?(file)
 
+        apply_cli_overrides(params['cli_overrides'])
         src, result = rewrite_file(file, strategy)
         send_result(client, id, 'status' => result[:output] == src ? 'ok' : 'fail',
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
       end
 
-      # Handle a fix request: read file, rewrite, write back.
-      #
-      # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] params request parameters
-      # @return [Object]
       def handle_fix(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
         return send_error(client, id, -32_602, "File not found: #{file}") unless file && File.file?(file)
 
+        apply_cli_overrides(params['cli_overrides'])
         src, result = rewrite_file(file, strategy)
         File.write(file, result[:output]) if result[:output] != src
         send_result(client, id, 'status' => 'ok',
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
       end
 
-      # Read file, run InlineRewriter, and return [src, result].
-      #
-      # @private
-      # @param [Object] file path to file
-      # @param [Object] strategy rewrite strategy
-      # @return [Array] original source and rewrite result
+      def apply_cli_overrides(overrides)
+        return if overrides.nil? || overrides.empty?
+        return if @applied_overrides == overrides
+
+        config = @config or return
+        require 'docscribe/cli/config_builder'
+        opts = overrides.transform_keys(&:to_sym)
+        @effective_config = Docscribe::CLI::ConfigBuilder.build(config, opts)
+        @applied_overrides = overrides
+      end
+
       def rewrite_file(file, strategy)
+        config = @effective_config || @config or raise 'Docscribe: config not loaded'
         key = [file, strategy]
         mtime = File.mtime(file)
         hit = @file_cache[key]
         return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
 
         src = File.read(file)
-        result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: @config, core_rbs_provider: @core_rbs_provider, file: file)
+        rbs = config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil
+        result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: config, core_rbs_provider: rbs, file: file)
         @file_cache[key] = { mtime: mtime, src: src, result: result }
         [src, result]
       end
@@ -485,20 +475,12 @@ module Docscribe
       # @return [nil]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }
-        client.puts(Protocol.serialize(response))
+        client.write(Protocol.serialize(response))
       end
 
-      # Send a JSON-RPC error response.
-      #
-      # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] code error code
-      # @param [Object] message error message
-      # @return [nil]
       def send_error(client, id, code, message)
         response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
-        client.puts(Protocol.serialize(response))
+        client.write(Protocol.serialize(response))
       end
 
       # Cleanup socket and PID files on shutdown.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -460,10 +460,7 @@ module Docscribe
         return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
 
         src = File.read(file)
-        result = Docscribe::InlineRewriter.rewrite_with_report(
-          src, strategy: strategy, config: @config,
-               core_rbs_provider: @core_rbs_provider, file: file
-        )
+        result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: @config, core_rbs_provider: @core_rbs_provider, file: file)
         @file_cache[key] = { mtime: mtime, src: src, result: result }
         [src, result]
       end

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -294,6 +294,7 @@ module Docscribe
         @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @running = false
         @server = nil
+        @file_cache = {}
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.
@@ -349,7 +350,6 @@ module Docscribe
         while @running
           check_idle_timeout
           accept_client
-          @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         end
       rescue Interrupt
         @running = false
@@ -375,6 +375,7 @@ module Docscribe
         return unless client
 
         handle_client(client)
+        @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
 
       # Read a request from a client connection and dispatch it.
@@ -452,12 +453,18 @@ module Docscribe
       # @param [Object] file path to file
       # @param [Object] strategy rewrite strategy
       # @return [Array] original source and rewrite result
-      def rewrite_file(file, strategy)
+      def rewrite_file(file, strategy) # rubocop:disable Metrics/MethodLength
+        key = [file, strategy]
+        mtime = File.mtime(file)
+        hit = @file_cache[key]
+        return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
+
         src = File.read(file)
         result = Docscribe::InlineRewriter.rewrite_with_report(
           src, strategy: strategy, config: @config,
                core_rbs_provider: @core_rbs_provider, file: file
         )
+        @file_cache[key] = { mtime: mtime, src: src, result: result }
         [src, result]
       end
 

--- a/lib/docscribe/types/sorbet/base_provider.rb
+++ b/lib/docscribe/types/sorbet/base_provider.rb
@@ -18,10 +18,12 @@ module Docscribe
         # Initialize
         #
         # @param [Boolean] collapse_generics whether generic container details
+        # @param [Boolean] collapse_object_generics collapse Object generics
         # @return [void]
-        def initialize(collapse_generics: false)
+        def initialize(collapse_generics: false, collapse_object_generics: false)
           require 'rbs'
           @collapse_generics = !!collapse_generics
+          @collapse_object_generics = !!collapse_object_generics
           @index = {}
           @warned = false
         end
@@ -210,7 +212,8 @@ module Docscribe
         def format_type(type)
           Docscribe::Types::RBS::TypeFormatter.to_yard(
             type,
-            collapse_generics: @collapse_generics
+            collapse_generics: @collapse_generics,
+            collapse_object_generics: @collapse_object_generics
           )
         end
 
@@ -220,7 +223,7 @@ module Docscribe
         # @param [String] name method name
         # @return [String]
         def normalize_container(name)
-          name.to_s.delete_prefix('::')
+          name.to_s.delete_prefix('::').sub(/\[.*\]/, '').sub(/<.*>/, '')
         end
 
         # Print one debug warning per provider instance when debugging is enabled.

--- a/lib/docscribe/types/sorbet/rbi_provider.rb
+++ b/lib/docscribe/types/sorbet/rbi_provider.rb
@@ -16,9 +16,10 @@ module Docscribe
         #
         # @param [Array<String>] rbi_dirs directories scanned recursively for
         # @param [Boolean] collapse_generics whether generic container types
+        # @param [Boolean] collapse_object_generics collapse Object generics
         # @return [void]
-        def initialize(rbi_dirs:, collapse_generics: false)
-          super(collapse_generics: collapse_generics)
+        def initialize(rbi_dirs:, collapse_generics: false, collapse_object_generics: false)
+          super(collapse_generics: collapse_generics, collapse_object_generics: collapse_object_generics)
 
           Array(rbi_dirs).each do |dir|
             path = Pathname(dir)

--- a/lib/docscribe/types/sorbet/source_provider.rb
+++ b/lib/docscribe/types/sorbet/source_provider.rb
@@ -15,9 +15,10 @@ module Docscribe
         # @param [String] source Ruby source containing inline `sig` declarations
         # @param [String] file source label used in diagnostics/debug warnings
         # @param [Boolean] collapse_generics whether generic container types
+        # @param [Boolean] collapse_object_generics collapse Object generics
         # @return [void]
-        def initialize(source:, file:, collapse_generics: false)
-          super(collapse_generics: collapse_generics)
+        def initialize(source:, file:, collapse_generics: false, collapse_object_generics: false)
+          super(collapse_generics: collapse_generics, collapse_object_generics: collapse_object_generics)
           load_from_string(source, label: file)
         end
       end

--- a/sig/lib/docscribe/cli.rbs
+++ b/sig/lib/docscribe/cli.rbs
@@ -4,7 +4,7 @@ module Docscribe
       def run: (Array[String]) -> Integer
     end
 
-    COMMANDS: Hash[String, _Subcommand]
+    COMMANDS: Hash[String, Symbol]
 
     def self.run: (Array[String] argv) -> Integer
 

--- a/sig/lib/docscribe/cli/run.rbs
+++ b/sig/lib/docscribe/cli/run.rbs
@@ -3,9 +3,15 @@ module Docscribe
     module Run
       INITIAL_RUN_STATE: Formatters::state
 
+      CLI_OVERRIDE_KEYS: Array[Symbol]
+
       def self.run: (options: Formatters::opts, argv: Array[String]) -> Integer
 
       def self.run_via_server: (options: Formatters::opts, argv: Array[String]) -> Integer
+
+      def self.build_light_config: (Formatters::opts options) -> Config
+
+      def self.extract_cli_overrides: (Formatters::opts options) -> Hash[String, untyped]
 
       def self.run_files_via_server: (Docscribe::Server::Client client, Array[String] paths, Formatters::opts options) -> Integer
 

--- a/sig/lib/docscribe/config/sorbet.rbs
+++ b/sig/lib/docscribe/config/sorbet.rbs
@@ -17,5 +17,7 @@ module Docscribe
     def sorbet_rbi_dirs: () -> Array[String]
 
     def sorbet_collapse_generics?: () -> bool
+
+    def sorbet_collapse_object_generics?: () -> bool
   end
 end

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -9,6 +9,7 @@ module Docscribe
     def self?.socket_path: (?String? config_path) -> String
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
     def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> void
+    def self?.start_daemon_process: (config_path: String?, daemonize: bool) -> void
     def self?.handle_stale_socket?: (String? config_path) -> bool
     def self?.process_alive?: (Integer pid) -> bool
     def self?.clean_socket_files: (String? config_path) -> void
@@ -44,6 +45,8 @@ module Docscribe
       @config_path: String?
       @core_rbs_provider: untyped
       @file_cache: untyped
+      @effective_config: Docscribe::Config?
+      @applied_overrides: Hash[String, untyped]?
 
       def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
       def start: () -> void
@@ -60,6 +63,7 @@ module Docscribe
       def handle_request: (UNIXSocket, Hash[String, untyped]) -> void
       def handle_check: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def handle_fix: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
+      def apply_cli_overrides: (Hash[String, untyped]?) -> void
       def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -43,6 +43,7 @@ module Docscribe
       @config: Docscribe::Config?
       @config_path: String?
       @core_rbs_provider: untyped
+      @file_cache: untyped
 
       def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
       def start: () -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -8,7 +8,7 @@ module Docscribe
     def self?.pid_path: (?String? config_path) -> String
     def self?.socket_path: (?String? config_path) -> String
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
-    def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> void
+    def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> bool
     def self?.start_daemon_process: (config_path: String?, daemonize: bool) -> void
     def self?.handle_stale_socket?: (String? config_path) -> bool
     def self?.process_alive?: (Integer pid) -> bool
@@ -24,8 +24,8 @@ module Docscribe
       @socket_path: String
 
       def initialize: (?String? socket_path, ?config_path: String?) -> void
-      def check: (file: String, ?strategy: Symbol) -> Hash[String, untyped]?
-      def fix: (file: String, ?strategy: Symbol) -> Hash[String, untyped]?
+      def check: (file: String, ?strategy: Symbol, **untyped) -> Hash[String, untyped]?
+      def fix: (file: String, ?strategy: Symbol, **untyped) -> Hash[String, untyped]?
 
       def shutdown: () -> Hash[String, untyped]?
 

--- a/sig/lib/docscribe/types/sorbet/base_provider.rbs
+++ b/sig/lib/docscribe/types/sorbet/base_provider.rbs
@@ -4,11 +4,13 @@ module Docscribe
       class BaseProvider
         @collapse_generics: bool
 
+        @collapse_object_generics: bool
+
         @index: Hash[ [ String, Symbol, Symbol ], Types::MethodSignature ]
 
         @warned: bool
 
-        def initialize: (?collapse_generics: bool) -> void
+        def initialize: (?collapse_generics: bool, ?collapse_object_generics: bool) -> void
 
         def signature_for: (container: String, scope: Symbol, name: (Symbol | String)) -> (Types::MethodSignature | nil)
 

--- a/sig/lib/docscribe/types/sorbet/rbi_provider.rbs
+++ b/sig/lib/docscribe/types/sorbet/rbi_provider.rbs
@@ -2,7 +2,7 @@ module Docscribe
   module Types
     module Sorbet
       class RBIProvider < BaseProvider
-        def initialize: (rbi_dirs: Array[String], ?collapse_generics: bool) -> void
+        def initialize: (rbi_dirs: Array[String], ?collapse_generics: bool, ?collapse_object_generics: bool) -> void
       end
     end
   end

--- a/sig/lib/docscribe/types/sorbet/source_provider.rbs
+++ b/sig/lib/docscribe/types/sorbet/source_provider.rbs
@@ -2,7 +2,7 @@ module Docscribe
   module Types
     module Sorbet
       class SourceProvider < BaseProvider
-        def initialize: (source: String, file: String, ?collapse_generics: bool) -> void
+        def initialize: (source: String, file: String, ?collapse_generics: bool, ?collapse_object_generics: bool) -> void
       end
     end
   end

--- a/spec/config/defaults_consistency_spec.rb
+++ b/spec/config/defaults_consistency_spec.rb
@@ -53,17 +53,19 @@ RSpec.describe Docscribe::Config do
   end
 
   describe 'rbs section' do
-    it 'has matching enabled and collapse_generics', :aggregate_failures do
+    it 'has matching enabled and collapse settings', :aggregate_failures do
       expect(yaml.dig('rbs', 'enabled')).to eq(default.dig('rbs', 'enabled'))
       expect(yaml.dig('rbs', 'collapse_generics')).to eq(default.dig('rbs', 'collapse_generics'))
+      expect(yaml.dig('rbs', 'collapse_object_generics')).to eq(default.dig('rbs', 'collapse_object_generics'))
       expect(yaml.dig('rbs', 'sig_dirs')).to match_array(default.dig('rbs', 'sig_dirs'))
     end
   end
 
   describe 'sorbet section' do
-    it 'has matching enabled and collapse_generics', :aggregate_failures do
+    it 'has matching enabled and collapse settings', :aggregate_failures do
       expect(yaml.dig('sorbet', 'enabled')).to eq(default.dig('sorbet', 'enabled'))
       expect(yaml.dig('sorbet', 'collapse_generics')).to eq(default.dig('sorbet', 'collapse_generics'))
+      expect(yaml.dig('sorbet', 'collapse_object_generics')).to eq(default.dig('sorbet', 'collapse_object_generics'))
       expect(yaml.dig('sorbet', 'rbi_dirs')).to match_array(default.dig('sorbet', 'rbi_dirs'))
     end
   end

--- a/spec/docscribe/cli/banner_spec.rb
+++ b/spec/docscribe/cli/banner_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Docscribe::CLI do
       end
 
       it "has BANNER constant in #{File.basename(file)}" do
+        require "docscribe/cli/#{File.basename(file, '.rb')}"
         expect(Object.const_get(BannerSpecHelper.module_name(file))).to be_const_defined(:BANNER)
       end
     end

--- a/spec/docscribe/cli/check_for_comments_spec.rb
+++ b/spec/docscribe/cli/check_for_comments_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'open3'
 require 'docscribe/cli'
+require 'docscribe/cli/check_for_comments'
 
 def resolve_config(raw, param_doc)
   instance_double(Docscribe::Config, raw: raw, param_documentation: param_doc)

--- a/spec/docscribe/cli/generate_spec.rb
+++ b/spec/docscribe/cli/generate_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'docscribe/cli'
+require 'docscribe/cli/generate'
 require 'tmpdir'
 require 'fileutils'
 

--- a/spec/docscribe/cli/server_spec.rb
+++ b/spec/docscribe/cli/server_spec.rb
@@ -184,4 +184,31 @@ RSpec.describe Docscribe::CLI do
       end
     end
   end
+
+  describe 'docscribe-client thin executable' do
+    let(:dir) { Dir.mktmpdir }
+    let(:thin_exe) { File.expand_path('exe/docscribe-client') }
+    let(:file) { "#{dir}/test.rb" }
+
+    before do
+      File.write(file, <<~RUBY)
+        def hello
+          puts 'world'
+        end
+      RUBY
+      Open3.capture3(RbConfig.ruby, exe, 'server', 'start', chdir: dir)
+    end
+
+    after do
+      Open3.capture3(RbConfig.ruby, exe, 'server', 'stop', chdir: dir)
+      FileUtils.remove_entry(dir)
+    end
+
+    it 'checks a file and returns JSON', :aggregate_failures do
+      out, _, st = Open3.capture3(RbConfig.ruby, thin_exe, '--check', file, chdir: dir)
+      result = JSON.parse(out)
+      expect(result.dig('result', 'status')).to eq('fail')
+      expect(st.exitstatus).to eq(0)
+    end
+  end
 end

--- a/spec/docscribe/cli/sigs_spec.rb
+++ b/spec/docscribe/cli/sigs_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'open3'
 require 'docscribe/cli'
+require 'docscribe/cli/sigs'
 
 RSpec.describe Docscribe::CLI::Sigs do
   describe 'helper methods' do

--- a/spec/docscribe/cli/update_types_spec.rb
+++ b/spec/docscribe/cli/update_types_spec.rb
@@ -4,6 +4,7 @@ require 'tmpdir'
 require 'fileutils'
 require 'open3'
 require 'docscribe/cli'
+require 'docscribe/cli/update_types'
 
 DEFAULT_OPTS = Docscribe::CLI::Options::DEFAULT.dup
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -71,14 +71,15 @@ RSpec.describe Docscribe::Server do
 
   describe '.ensure_running!' do
     before do
-      allow(described_class).to receive(:running?).and_return(false)
-      allow(described_class).to receive(:wait_for_ready)
+      allow(described_class).to receive(:wait_for_ready).and_return(false)
       allow(Process).to receive(:fork).and_return(12_345)
       allow(Process).to receive(:detach)
     end
 
     it 'returns early when server is already running' do
-      allow(described_class).to receive(:running?).and_return(true)
+      allow(described_class).to receive(:wait_for_ready)
+        .with(config_path: nil, timeout: 0, raise_on_timeout: false)
+        .and_return(true)
       expect { described_class.ensure_running! }.not_to raise_error
     end
 
@@ -94,7 +95,7 @@ RSpec.describe Docscribe::Server do
 
     it 'calls wait_for_ready after fork' do
       described_class.ensure_running!
-      expect(described_class).to have_received(:wait_for_ready)
+      expect(described_class).to have_received(:wait_for_ready).at_least(:once)
     end
   end
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Docscribe::Server do
       end
     end
 
-    describe 'idle timeout' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    describe 'idle timeout' do
       let(:idle_dir) { Dir.mktmpdir }
       let(:idle_sock) { "#{idle_dir}/idle.sock" }
 
@@ -367,7 +367,7 @@ RSpec.describe Docscribe::Server do
       end
     end
 
-    describe 'file cache' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    describe 'file cache' do
       let(:tmpdir) { Dir.mktmpdir }
       let(:test_file) { "#{tmpdir}/test.rb" }
       let(:daemon) { described_class.new(socket_path: "#{tmpdir}/cache.sock", idle_timeout: 60) }

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -354,35 +354,40 @@ RSpec.describe Docscribe::Server do
     end
 
     describe 'idle timeout' do
-      let(:idle_dir) { Dir.mktmpdir }
-      let(:idle_sock) { "#{idle_dir}/idle.sock" }
-
-      after { FileUtils.remove_entry(idle_dir) }
+      def with_idle_daemon(timeout)
+        Dir.mktmpdir do |dir|
+          sock = "#{dir}/idle.sock"
+          daemon = described_class.new(socket_path: sock, idle_timeout: timeout)
+          thread = Thread.new { daemon.start }
+          sleep 0.1 until File.exist?(sock)
+          yield daemon, thread
+        end
+      end
 
       it 'stops the daemon when idle timeout expires' do
-        daemon = described_class.new(socket_path: idle_sock, idle_timeout: 0.3)
-        thread = Thread.new { daemon.start }
-        sleep 0.1 until File.exist?(idle_sock)
-        expect(thread.join(2)).to be(thread)
+        with_idle_daemon(0.3) do |_daemon, thread|
+          expect(thread.join(2)).to be(thread)
+        end
       end
     end
 
     describe 'file cache' do
-      let(:tmpdir) { Dir.mktmpdir }
-      let(:test_file) { "#{tmpdir}/test.rb" }
-      let(:daemon) { described_class.new(socket_path: "#{tmpdir}/cache.sock", idle_timeout: 60) }
-
-      after { FileUtils.remove_entry(tmpdir) }
-
-      before do
-        File.write(test_file, "def foo\nend")
-        daemon.send(:load_dependencies)
+      def with_cache_dir
+        Dir.mktmpdir do |dir|
+          test_file = "#{dir}/test.rb"
+          daemon = described_class.new(socket_path: "#{dir}/cache.sock", idle_timeout: 60)
+          File.write(test_file, "def foo\nend")
+          daemon.send(:load_dependencies)
+          yield daemon, test_file
+        end
       end
 
       it 'caches across repeated calls' do
-        orig = daemon.send(:rewrite_file, test_file, :safe)
-        allow(Docscribe::InlineRewriter).to receive(:rewrite_with_report) { raise 'called twice' }
-        expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
+        with_cache_dir do |daemon, test_file|
+          orig = daemon.send(:rewrite_file, test_file, :safe)
+          allow(Docscribe::InlineRewriter).to receive(:rewrite_with_report) { raise 'called twice' }
+          expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
+        end
       end
     end
   end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -352,5 +352,38 @@ RSpec.describe Docscribe::Server do
         expect(File.exist?(socket_path)).to be false
       end
     end
+
+    describe 'idle timeout' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:idle_dir) { Dir.mktmpdir }
+      let(:idle_sock) { "#{idle_dir}/idle.sock" }
+
+      after { FileUtils.remove_entry(idle_dir) }
+
+      it 'stops the daemon when idle timeout expires' do
+        daemon = described_class.new(socket_path: idle_sock, idle_timeout: 0.3)
+        thread = Thread.new { daemon.start }
+        sleep 0.1 until File.exist?(idle_sock)
+        expect(thread.join(2)).to be(thread)
+      end
+    end
+
+    describe 'file cache' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+      let(:tmpdir) { Dir.mktmpdir }
+      let(:test_file) { "#{tmpdir}/test.rb" }
+      let(:daemon) { described_class.new(socket_path: "#{tmpdir}/cache.sock", idle_timeout: 60) }
+
+      after { FileUtils.remove_entry(tmpdir) }
+
+      before do
+        File.write(test_file, "def foo\nend")
+        daemon.send(:load_dependencies)
+      end
+
+      it 'caches across repeated calls' do
+        orig = daemon.send(:rewrite_file, test_file, :safe)
+        allow(Docscribe::InlineRewriter).to receive(:rewrite_with_report) { raise 'called twice' }
+        expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
+      end
+    end
   end
 end

--- a/spec/docscribe/types/rbs/type_formatter_spec.rb
+++ b/spec/docscribe/types/rbs/type_formatter_spec.rb
@@ -118,5 +118,51 @@ RSpec.describe 'Docscribe::Types::RBS::TypeFormatter' do
         expect(yard(type)).to eq('Integer')
       end
     end
+
+    describe 'collapse_object_generics option' do
+      let(:object_type) { RBS::Types::Bases::Any.new(location: nil) }
+      let(:string_type) { RBS::Types::ClassInstance.new(name: type_name('::String'), args: [], location: nil) }
+      let(:integer_type) { RBS::Types::ClassInstance.new(name: type_name('::Integer'), args: [], location: nil) }
+
+      def yard_cog(type, collapse_object_generics: false)
+        Docscribe::Types::RBS::TypeFormatter.to_yard(type, collapse_object_generics: collapse_object_generics)
+      end
+
+      it 'keeps Array<Object> when collapse_object_generics is false (default)' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [object_type], location: nil)
+        expect(yard_cog(type)).to eq('Array<Object>')
+      end
+
+      it 'collapses Array<Object> to Array when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [object_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Array')
+      end
+
+      it 'keeps Array<String> when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [string_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Array<String>')
+      end
+
+      it 'keeps Array<Integer> when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [integer_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Array<Integer>')
+      end
+
+      it 'collapses Hash<Object, Object> to Hash when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Hash'), args: [object_type, object_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Hash')
+      end
+
+      it 'keeps Hash<String, Integer> when collapse_object_generics is true' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Hash'), args: [string_type, integer_type], location: nil)
+        expect(yard_cog(type, collapse_object_generics: true)).to eq('Hash<String, Integer>')
+      end
+
+      it 'collapse_generics overrides collapse_object_generics' do
+        type = RBS::Types::ClassInstance.new(name: type_name('::Array'), args: [string_type], location: nil)
+        result = Docscribe::Types::RBS::TypeFormatter.to_yard(type, collapse_generics: true, collapse_object_generics: false)
+        expect(result).to eq('Array')
+      end
+    end
   end
 end

--- a/spec/integrations/sorbet/collapse_object_generics_spec.rb
+++ b/spec/integrations/sorbet/collapse_object_generics_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe Docscribe::InlineRewriter do
+  before { skip_unless_sorbet_bridge_available! }
+
+  let(:code) do
+    <<~RUBY
+      class Demo
+        extend T::Sig
+
+        sig { returns(T::Array[T.untyped]) }
+        def foo
+          []
+        end
+      end
+    RUBY
+  end
+
+  let(:strategy) { :safe }
+
+  describe 'when collapse_object_generics is false (default)' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_object_generics' => false }
+                   ))
+    end
+
+    it 'keeps Array<Object> in @return tag' do
+      expect(out).to include('# @return [Array<Object>]')
+      expect(out).not_to include('# @return [Array]')
+    end
+  end
+
+  describe 'when collapse_object_generics is true' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_object_generics' => true }
+                   ))
+    end
+
+    it 'collapses Array<Object> to Array in @return tag' do
+      expect(out).to include('# @return [Array]')
+      expect(out).not_to include('# @return [Array<Object>]')
+    end
+  end
+
+  describe 'when collapsible generics contain non-Object types' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_object_generics' => true }
+                   ))
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          extend T::Sig
+
+          sig { returns(T::Array[Integer]) }
+          def foo
+            []
+          end
+        end
+      RUBY
+    end
+
+    it 'keeps Array<Integer> when collapse_object_generics is true' do
+      expect(out).to include('# @return [Array<Integer>]')
+      expect(out).not_to include('# @return [Array]')
+    end
+  end
+
+  describe 'when collapse_generics overrides collapse_object_generics' do
+    subject(:out) do
+      inline(code, strategy: strategy,
+                   config: Docscribe::Config.new(
+                     'sorbet' => { 'enabled' => true, 'collapse_generics' => true, 'collapse_object_generics' => false }
+                   ))
+    end
+
+    let(:code) do
+      <<~RUBY
+        class Demo
+          extend T::Sig
+
+          sig { returns(T::Array[Integer]) }
+          def foo
+            []
+          end
+        end
+      RUBY
+    end
+
+    it 'collapse_generics collapses even non-Object generics' do
+      expect(out).to include('# @return [Array]')
+      expect(out).not_to include('# @return [Array<Integer>]')
+    end
+  end
+end

--- a/spec/integrations/sorbet/collapse_object_generics_spec.rb
+++ b/spec/integrations/sorbet/collapse_object_generics_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Docscribe::InlineRewriter do
                    ))
     end
 
-    it 'keeps Array<Object> in @return tag' do
+    it 'keeps Array<Object> in @return tag', :aggregate_failures do
       expect(out).to include('# @return [Array<Object>]')
       expect(out).not_to include('# @return [Array]')
     end
@@ -40,7 +40,7 @@ RSpec.describe Docscribe::InlineRewriter do
                    ))
     end
 
-    it 'collapses Array<Object> to Array in @return tag' do
+    it 'collapses Array<Object> to Array in @return tag', :aggregate_failures do
       expect(out).to include('# @return [Array]')
       expect(out).not_to include('# @return [Array<Object>]')
     end
@@ -67,7 +67,7 @@ RSpec.describe Docscribe::InlineRewriter do
       RUBY
     end
 
-    it 'keeps Array<Integer> when collapse_object_generics is true' do
+    it 'keeps Array<Integer> when collapse_object_generics is true', :aggregate_failures do
       expect(out).to include('# @return [Array<Integer>]')
       expect(out).not_to include('# @return [Array]')
     end
@@ -94,7 +94,7 @@ RSpec.describe Docscribe::InlineRewriter do
       RUBY
     end
 
-    it 'collapse_generics collapses even non-Object generics' do
+    it 'collapse_generics collapses even non-Object generics', :aggregate_failures do
       expect(out).to include('# @return [Array]')
       expect(out).not_to include('# @return [Array<Integer>]')
     end


### PR DESCRIPTION
## Description

- **Thin client path for IDE** — lightweight `docscribe-client` entry point that loads only socket + JSON, no `InlineRewriter`. Lazy `require` in `cli.rb` / `cli/run.rb`.
- **Idle timeout fix** — `@last_request_time` updated only on real client connection, not every `listen_loop` iteration. Daemon now correctly shuts down on timeout.
- **Sorbet generics support** — strip generic parameters (`<...>` / `[...]`) from container name in `BaseProvider`. Added `collapse_object_generics` option to `config/sorbet.rb`.
- **Lock-file** — `docscribe.lock` with `flock` for server start/stop synchronization across processes.
- **Protocol fix** — switched from `to_json` + `puts` to `JSON.generate` (fixed double `\n` in requests).
- **Config overrides** — `cli_overrides` no longer lost during runtime configuration.
- **Waterfall cycle bug fix** — recursion `check_for_comments` → `check` → `check_for_comments` resolved.
- **RuboCop / Steep fixes** — code style and type warnings.

## Testing

- `bundle exec rspec spec/docscribe/server_spec.rb`
- `bundle exec rspec spec/docscribe/types/rbs/type_formatter_spec.rb`
- `bundle exec rspec spec/docscribe/cli/server_spec.rb`