### PR TITLE
[1.5.1] Include `Gemfile.lock` + `rbs_collection.lock.yaml` mtime in socket key

### DIFF
--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -8,17 +8,27 @@ require 'securerandom'
 require 'digest/md5'
 
 SOCKET_DIR = '/tmp'
+ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
 def socket_path(config_path = nil)
   hash = Digest::MD5.hexdigest(Dir.pwd)
-  if config_path
-    resolved = File.expand_path(config_path)
-    mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
-    cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
-    "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
-  else
-    "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+  env_seed = env_hash
+  suffix = config_path ? "-#{config_hash(config_path)}" : ''
+  "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+end
+
+def env_hash
+  parts = ENV_FILES.map do |file|
+    path = File.join(Dir.pwd, file)
+    File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
   end
+  Digest::MD5.hexdigest(parts.join(':'))
+end
+
+def config_hash(config_path)
+  resolved = File.expand_path(config_path)
+  mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+  Digest::MD5.hexdigest("#{resolved}:#{mtime}")
 end
 
 def send_request(sock, method, params = {})

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -140,24 +140,42 @@ module Docscribe
         "#{socket_path(config_path)}.pid"
       end
 
+      ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
+
       # Derive a project-specific socket path from the current working directory.
       # Uses MD5 (deterministic across processes) instead of String#hash
       # (which varies per Ruby process due to random seeding).
       # When a config_path is given, its path + mtime are included in the hash
       # so different configs get different daemons.
+      # Environment files (Gemfile.lock, rbs_collection.lock.yaml) are also
+      # included so daemon is invalidated when gems or RBS types change.
       #
       # @param [String?] config_path optional config path to differentiate
       # @return [String]
       def socket_path(config_path = nil)
         hash = Digest::MD5.hexdigest(Dir.pwd)
-        if config_path
-          resolved = File.expand_path(config_path)
-          mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
-          cfg_hash = Digest::MD5.hexdigest("#{resolved}:#{mtime}")
-          "#{SOCKET_DIR}/docscribe-#{hash}-#{cfg_hash}.sock"
-        else
-          "#{SOCKET_DIR}/docscribe-#{hash}.sock"
+        env_seed = env_hash
+        suffix = config_path ? "-#{config_hash(config_path)}" : ''
+        "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+      end
+
+      # @param [String] config_path
+      # @return [String]
+      def config_hash(config_path)
+        resolved = File.expand_path(config_path)
+        mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+        Digest::MD5.hexdigest("#{resolved}:#{mtime}")
+      end
+
+      # Hash of environment files that affect analysis results.
+      # When any of these change, the daemon is invalidated (new socket path).
+      # @return [String]
+      def env_hash
+        parts = ENV_FILES.map do |file|
+          path = File.join(Dir.pwd, file)
+          File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
         end
+        Digest::MD5.hexdigest(parts.join(':'))
       end
 
       public :read_pid, :pid_path, :socket_path

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -2,11 +2,14 @@ module Docscribe
   module Server
     SOCKET_DIR: String
     IDLE_TIMEOUT: Integer
+    ENV_FILES: Array[String]
 
     def self?.running?: (?String? config_path) -> bool
     def self?.read_pid: (?String? config_path) -> Integer?
     def self?.pid_path: (?String? config_path) -> String
     def self?.socket_path: (?String? config_path) -> String
+    def self?.config_hash: (String config_path) -> String
+    def self?.env_hash: () -> String
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
     def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> bool
     def self?.start_daemon_process: (config_path: String?, daemonize: bool) -> void


### PR DESCRIPTION
## Description

Daemon now invalidates when project environment changes (`Gemfile.lock`, `rbs_collection.lock.yaml`). Mtime of these files is included in the socket key hash — when they change, the socket path differs, and clients automatically spawn a fresh daemon instead of hitting stale state.

- `lib/docscribe/server.rb` — `socket_path` includes `env_hash` from `Gemfile.lock` + `rbs_collection.lock.yaml` mtimes
- `exe/docscribe-client` — kept in sync with the same logic