### PR TITLE
[1.5.1] Preserve `config_path` in `ConfigBuilder`, clear file cache on overrides

### DIFF
--- a/lib/docscribe/cli/config_builder.rb
+++ b/lib/docscribe/cli/config_builder.rb
@@ -29,7 +29,7 @@ module Docscribe
         apply_rbs_overrides(raw, options) if rbs_overrides?(options)
         apply_sorbet_overrides(raw, options) if sorbet_overrides?(options)
         apply_output_overrides(raw, options)
-        conf = Docscribe::Config.new(**raw)
+        conf = Docscribe::Config.new(config_path: base.config_path, **raw)
         warn_missing_rbs_collection(conf, options)
         conf
       end

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -481,6 +481,7 @@ module Docscribe
         require 'docscribe/cli/config_builder'
         opts = overrides.transform_keys(&:to_sym)
         @effective_config = Docscribe::CLI::ConfigBuilder.build(config, opts)
+        @file_cache.clear
         @applied_overrides = overrides
       end
 

--- a/spec/docscribe/cli/config_builder_spec.rb
+++ b/spec/docscribe/cli/config_builder_spec.rb
@@ -96,7 +96,17 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
   end
 
   describe 'build' do
-    let(:base) { Docscribe::Config.new }
+    let(:base) { Docscribe::Config.new(config_path: '/tmp/.docscribe/test.yml') }
+
+    it 'preserves config_path from base without overrides' do
+      config = described_class.build(base, default_options)
+      expect(config.config_path).to eq('/tmp/.docscribe/test.yml')
+    end
+
+    it 'preserves config_path from base with overrides' do
+      config = described_class.build(base, default_options.merge(no_boilerplate: true))
+      expect(config.config_path).to eq('/tmp/.docscribe/test.yml')
+    end
 
     it 'sets emit flags when no_boilerplate is in options', :aggregate_failures do
       config = described_class.build(base, default_options.merge(no_boilerplate: true))

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -390,6 +390,14 @@ RSpec.describe Docscribe::Server do
           expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
         end
       end
+
+      it 'clears cache when cli overrides change' do
+        with_cache_dir do |daemon, test_file|
+          daemon.send(:rewrite_file, test_file, :safe)
+          daemon.send(:apply_cli_overrides, Docscribe::CLI::Options::DEFAULT.merge(no_boilerplate: true).transform_keys(&:to_s))
+          expect(daemon.instance_variable_get(:@file_cache)).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

**ConfigBuilder.build** now preserves `config_path` from the base config. Previously, `Docscribe::Config.new(**raw)` was called without `config_path:`, causing the path to be lost when CLI overrides were applied. This broke socket path differentiation per config file.

**File cache** in the daemon is now cleared when CLI overrides change. Previously, `@file_cache` wasn't invalidated when a new effective config was built, so a file with the same mtime could return stale results computed under different overrides.

### Changes

- `lib/docscribe/cli/config_builder.rb` — pass `config_path: base.config_path` to `Config.new`
- `lib/docscribe/server.rb` — `@file_cache.clear` after rebuilding `@effective_config`

### Tests

- `spec/docscribe/cli/config_builder_spec.rb` — verifies `config_path` is preserved with and without overrides
- `spec/docscribe/server_spec.rb` — verifies cache is cleared when overrides change

### Checklist

- [x] RuboCop — 0 offenses
- [x] Steep — no type errors
- [x] RSpec — 1002 examples, 0 failures