### PR TITLE
[1.5.1] Fixed: preserve `config_path` in `ConfigBuilder`, clear file cache on overrides

### DIFF
--- a/lib/docscribe/cli/config_builder.rb
+++ b/lib/docscribe/cli/config_builder.rb
@@ -29,7 +29,7 @@ module Docscribe
         apply_rbs_overrides(raw, options) if rbs_overrides?(options)
         apply_sorbet_overrides(raw, options) if sorbet_overrides?(options)
         apply_output_overrides(raw, options)
-        conf = Docscribe::Config.new(**raw)
+        conf = Docscribe::Config.new(config_path: base.config_path, **raw)
         warn_missing_rbs_collection(conf, options)
         conf
       end

--- a/lib/docscribe/lru_cache.rb
+++ b/lib/docscribe/lru_cache.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Docscribe
+  # Bounded LRU cache with O(1) access and eviction.
+  # Used by Server::Daemon for file rewrite caching.
+  class LRUCache
+    # @param [Integer] max_size
+    # @return [void]
+    def initialize(max_size = 1000)
+      @max_size = max_size
+      @data = {}
+    end
+
+    # @param [Object] key
+    # @return [Object]
+    def [](key)
+      val = @data[key]
+      return nil unless val
+
+      @data.delete(key)
+      @data[key] = val
+      val
+    end
+
+    # @param [Object] key
+    # @param [Object] val
+    # @return [Object]
+    def []=(key, val)
+      @data.delete(key) if @data.key?(key)
+      @data[key] = val
+      @data.shift if @data.size > @max_size
+    end
+
+    # @return [void]
+    def clear
+      @data.clear
+    end
+
+    # @return [Boolean]
+    def empty?
+      @data.empty?
+    end
+
+    # @return [Integer]
+    def size
+      @data.size
+    end
+  end
+end

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -481,6 +481,7 @@ module Docscribe
         require 'docscribe/cli/config_builder'
         opts = overrides.transform_keys(&:to_sym)
         @effective_config = Docscribe::CLI::ConfigBuilder.build(config, opts)
+        @file_cache.clear
         @applied_overrides = overrides
       end
 

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -5,6 +5,7 @@ require 'socket'
 require 'fileutils'
 require 'securerandom'
 require 'digest/md5'
+require_relative 'lru_cache'
 
 module Docscribe
   # Server/daemon mode for persistent multi-request operation.
@@ -169,6 +170,7 @@ module Docscribe
 
       # Hash of environment files that affect analysis results.
       # When any of these change, the daemon is invalidated (new socket path).
+      #
       # @return [String]
       def env_hash
         parts = ENV_FILES.map do |file|
@@ -313,7 +315,7 @@ module Docscribe
       # @param [nil] socket_path custom socket path
       # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
       # @param [nil] config_path custom config path
-      # @return [Hash]
+      # @return [LRUCache]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
@@ -321,7 +323,7 @@ module Docscribe
         @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @running = false
         @server = nil
-        @file_cache = {}
+        @file_cache = LRUCache.new
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.

--- a/sig/lib/docscribe/lru_cache.rbs
+++ b/sig/lib/docscribe/lru_cache.rbs
@@ -1,0 +1,13 @@
+module Docscribe
+  class LRUCache
+    @max_size: Integer
+    @data: Hash[untyped, untyped]
+
+    def initialize: (?Integer max_size) -> void
+    def []: (untyped key) -> untyped
+    def []=: (untyped key, untyped val) -> untyped
+    def clear: () -> void
+    def empty?: () -> bool
+    def size: () -> Integer
+  end
+end

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -47,7 +47,7 @@ module Docscribe
       @config: Docscribe::Config?
       @config_path: String?
       @core_rbs_provider: untyped
-      @file_cache: untyped
+      @file_cache: Docscribe::LRUCache
       @effective_config: Docscribe::Config?
       @applied_overrides: Hash[String, untyped]?
 

--- a/spec/docscribe/cli/config_builder_spec.rb
+++ b/spec/docscribe/cli/config_builder_spec.rb
@@ -96,7 +96,17 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
   end
 
   describe 'build' do
-    let(:base) { Docscribe::Config.new }
+    let(:base) { Docscribe::Config.new(config_path: '/tmp/.docscribe/test.yml') }
+
+    it 'preserves config_path from base without overrides' do
+      config = described_class.build(base, default_options)
+      expect(config.config_path).to eq('/tmp/.docscribe/test.yml')
+    end
+
+    it 'preserves config_path from base with overrides' do
+      config = described_class.build(base, default_options.merge(no_boilerplate: true))
+      expect(config.config_path).to eq('/tmp/.docscribe/test.yml')
+    end
 
     it 'sets emit flags when no_boilerplate is in options', :aggregate_failures do
       config = described_class.build(base, default_options.merge(no_boilerplate: true))

--- a/spec/docscribe/lru_cache_spec.rb
+++ b/spec/docscribe/lru_cache_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'docscribe/lru_cache'
+
+RSpec.describe Docscribe::LRUCache do
+  subject(:cache) { described_class.new(max_size) }
+
+  let(:max_size) { 3 }
+
+  describe '#[] and #[]=' do
+    it 'stores and retrieves values' do
+      cache[:a] = 1
+      expect(cache[:a]).to eq(1)
+    end
+
+    it 'returns nil for missing keys' do
+      expect(cache[:missing]).to be_nil
+    end
+
+    describe 'access order promotion' do
+      before do
+        cache[:a] = 1
+        cache[:b] = 2
+        cache[:c] = 3
+        cache[:a] # promote :a
+        cache[:d] = 4
+      end
+
+      it 'evicts least recently used after read' do
+        expect(cache[:b]).to be_nil
+      end
+
+      it 'keeps :a after promotion' do
+        expect(cache[:a]).to eq(1)
+      end
+
+      it 'keeps :c as recently used' do
+        expect(cache[:c]).to eq(3)
+      end
+
+      it 'stores the new entry' do
+        expect(cache[:d]).to eq(4)
+      end
+    end
+  end
+
+  describe '#size' do
+    it 'tracks number of entries' do
+      cache[:a] = 1
+      cache[:b] = 2
+      expect(cache.size).to eq(2)
+    end
+
+    it 'does not exceed max_size' do
+      max_size.times { |i| cache[i] = i }
+      cache[:extra] = 99
+      expect(cache.size).to eq(max_size)
+    end
+  end
+
+  describe '#clear' do
+    it 'empties the cache' do
+      cache[:a] = 1
+      cache.clear
+      expect(cache).to be_empty
+    end
+  end
+
+  describe '#empty?' do
+    it 'returns true when empty' do
+      expect(cache).to be_empty
+    end
+
+    it 'returns false with entries' do
+      cache[:a] = 1
+      expect(cache).not_to be_empty
+    end
+  end
+
+  describe 'eviction policy' do
+    before do
+      cache[:a] = 1
+      cache[:b] = 2
+      cache[:c] = 3
+    end
+
+    it 'evicts least recently used entries' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:b]).to be_nil
+    end
+
+    it 'retains :a after access' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:a]).to eq(1)
+    end
+
+    it 'retains :c as survivor' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:c]).to eq(3)
+    end
+
+    it 'stores the new entry' do
+      cache[:a] # access :a, now LRU is :b
+      cache[:d] = 4
+      expect(cache[:d]).to eq(4)
+    end
+
+    describe 'reinsertion on write' do
+      before do
+        cache[:a] = 10 # should move :a to front
+        cache[:d] = 4
+      end
+
+      it 'evicts the previous LRU' do
+        expect(cache[:b]).to be_nil
+      end
+
+      it 'keeps updated value' do
+        expect(cache[:a]).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -390,6 +390,14 @@ RSpec.describe Docscribe::Server do
           expect(daemon.send(:rewrite_file, test_file, :safe)).to eq(orig)
         end
       end
+
+      it 'clears cache when cli overrides change' do
+        with_cache_dir do |daemon, test_file|
+          daemon.send(:rewrite_file, test_file, :safe)
+          daemon.send(:apply_cli_overrides, Docscribe::CLI::Options::DEFAULT.merge(no_boilerplate: true).transform_keys(&:to_s))
+          expect(daemon.instance_variable_get(:@file_cache)).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

<!-- One-paragraph explanation of the change. -->

## Changes

<!-- Bullet list of what changed and why. -->

## Verification

- [ ] `bundle exec rspec` passes
- [ ] `bundle exec rubocop` — 0 offenses
- [ ] `bundle exec docscribe lib -C docscribe.yml` — OK
- [ ] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)
