### PR TITLE
[1.5.1] Server polish, fix RBS Provider stdlib loading, fix socket path on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 - **Server/daemon mode** (`docscribe server`):
     - Start/stop/status subcommand for a persistent background daemon.
-    - JSON-RPC 2.0 protocol over Unix socket (`check`, `fix`, `shutdown`).
+    - JSON-RPC 2.0 protocol over Unix socket (`check`, `fix`, `shutdown`, `ping`).
     - Idle timeout (5 minutes) — daemon auto-exits after inactivity.
     - `--server` flag for existing `docscribe` commands to use the daemon transparently.
 - **`docscribe-client`** — standalone thin client (`exe/docscribe-client`) for IDE plugins
   and CI. Connects to the daemon without loading the full docscribe gem.
+    - `--status` flag to check if the daemon is running (exit code 0/1).
+    - `--ping` flag to get version, pid, uptime, and socket path from the daemon.
 - **Env invalidation:** daemon socket path includes mtime of `Gemfile.lock` and
   `rbs_collection.lock.yaml`. Environment changes spawn a fresh daemon automatically.
 - **LRU file cache:** `Docscribe::LRUCache` (bounded at 1000 entries) caches parsed
@@ -21,6 +23,9 @@
     - `resolve_rbs_for_send` falls back to `signature_provider` (project RBS)
       when `core_rbs_provider` fails — enables type resolution for method calls
       on explicit receivers in rescue bodies.
+- **RBS Provider stdlib loading:** `Provider` now loads stdlib libraries
+  (`socket`, `json`, `digest`, etc.) from `rbs_collection.lock.yaml`, enabling
+  correct resolution of RBS files that reference stdlib types (e.g. `UNIXSocket`).
 
 ### Fixed
 
@@ -35,11 +40,24 @@
   extracted `resolve_rbs_for_send_with_signature_provider` to fix
   `Metrics/MethodLength` and `Metrics/ParameterLists`.
 - **RBS/Steep:** added signature for `resolve_rbs_for_send_with_signature_provider`.
+- **RBS Provider silently returning `Object` for all lookups:** `Provider` failed to
+  load stdlib RBS libraries (`socket`, `json`, etc.), causing `NoTypeFoundError` on
+  any sig referencing stdlib types. All `signature_for` calls fell back to inference
+  which returned `Object`, silently breaking `docscribe update_types`.
+- **Unix socket path exceeding OS limit on macOS:** `Dir.tmpdir` returns a long path
+  under `/var/folders/.../T`, causing `ArgumentError: too long unix socket path`
+  (max 104 bytes). The daemon crashed silently on startup. Fixed by falling back to
+  `/tmp` when `Dir.tmpdir` exceeds the socket path length limit.
 
 ### Changed
 
+- **`docscribe server status` now uses `ping` protocol** for extended info:
+  version, pid, socket path, uptime.
+- **Daemon auto-start no longer prints to stderr:** the `"Docscribe: starting server..."`
+  message is only emitted on explicit `docscribe server start`, not on implicit
+  auto-start via `--server`.
 - **README updated:** new Server mode section documenting daemon, thin client,
-  env invalidation, LRU cache, CLI override handling.
+  env invalidation, LRU cache, CLI override handling, ping protocol.
 - **Editor Integration section** updated to reference `docscribe-client` and daemon.
 
 ## 1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,53 +11,44 @@
   and CI. Connects to the daemon without loading the full docscribe gem.
     - `--status` flag to check if the daemon is running (exit code 0/1).
     - `--ping` flag to get version, pid, uptime, and socket path from the daemon.
-- **Env invalidation:** daemon socket path includes mtime of `Gemfile.lock` and
-  `rbs_collection.lock.yaml`. Environment changes spawn a fresh daemon automatically.
-- **LRU file cache:** `Docscribe::LRUCache` (bounded at 1000 entries) caches parsed
-  results per file by mtime, serving repeated checks nearly instantly.
+- **Env invalidation:** daemon socket path includes mtime of `Gemfile.lock` and `rbs_collection.lock.yaml`. Environment
+  changes spawn a fresh daemon automatically.
+- **LRU file cache:** `Docscribe::LRUCache` (bounded at 1000 entries) caches parsed results per file by mtime, serving
+  repeated checks nearly instantly.
 - **Rescue-aware type inference for parameters:**
-    - `handle_lvar_node` now uses `lookup_lvar_type` which checks both
-      `local_var_types` and `param_types` — rescue body returning a parameter
-      defaults to the correct type instead of `Object`.
+    - `handle_lvar_node` now uses `lookup_lvar_type` which checks both `local_var_types` and `param_types` — rescue body
+      returning a parameter defaults to the correct type instead of `Object`.
 - **Rescue-aware type inference for explicit receivers:**
-    - `resolve_rbs_for_send` falls back to `signature_provider` (project RBS)
-      when `core_rbs_provider` fails — enables type resolution for method calls
-      on explicit receivers in rescue bodies.
-- **RBS Provider stdlib loading:** `Provider` now loads stdlib libraries
-  (`socket`, `json`, `digest`, etc.) from `rbs_collection.lock.yaml`, enabling
-  correct resolution of RBS files that reference stdlib types (e.g. `UNIXSocket`).
+    - `resolve_rbs_for_send` falls back to `signature_provider` (project RBS) when `core_rbs_provider` fails — enables
+      type resolution for method calls on explicit receivers in rescue bodies.
+- **RBS Provider stdlib loading:** `Provider` now loads stdlib libraries (`socket`, `json`, `digest`, etc.) from
+  `rbs_collection.lock.yaml`, enabling correct resolution of RBS files that reference stdlib types (e.g. `UNIXSocket`).
 
 ### Fixed
 
-- **CLI override leak in daemon:** `apply_cli_overrides` now resets
-  `@effective_config`, `@applied_overrides`, and clears `@file_cache` when
-  overrides are `nil` or empty. Previously, stale overrides from a prior
-  request leaked into subsequent requests with no overrides.
-- **Duplicate `@return` tag in aggressive mode with rescue:** `merge_existing_descriptions!`
-  no longer treats machine-generated conditional annotations (e.g. `"if RuntimeError"`)
-  as human-written descriptions — skips `return_description` starting with `"if "`.
-- **RuboCop compliance:** 2 → 0 offenses in `lib/docscribe/infer/returns.rb`:
-  extracted `resolve_rbs_for_send_with_signature_provider` to fix
-  `Metrics/MethodLength` and `Metrics/ParameterLists`.
+- **CLI override leak in daemon:** `apply_cli_overrides` now resets `@effective_config`, `@applied_overrides`, and
+  clears `@file_cache` when overrides are `nil` or empty. Previously, stale overrides from a prior request leaked into
+  subsequent requests with no overrides.
+- **Duplicate `@return` tag in aggressive mode with rescue:** `merge_existing_descriptions!` no longer treats
+  machine-generated conditional annotations (e.g. `"if RuntimeError"`) as human-written descriptions — skips
+  `return_description` starting with `"if "`.
+- **RuboCop compliance:** 2 -> 0 offenses in `lib/docscribe/infer/returns.rb`: extracted
+  `resolve_rbs_for_send_with_signature_provider` to fix `Metrics/MethodLength` and `Metrics/ParameterLists`.
 - **RBS/Steep:** added signature for `resolve_rbs_for_send_with_signature_provider`.
-- **RBS Provider silently returning `Object` for all lookups:** `Provider` failed to
-  load stdlib RBS libraries (`socket`, `json`, etc.), causing `NoTypeFoundError` on
-  any sig referencing stdlib types. All `signature_for` calls fell back to inference
-  which returned `Object`, silently breaking `docscribe update_types`.
-- **Unix socket path exceeding OS limit on macOS:** `Dir.tmpdir` returns a long path
-  under `/var/folders/.../T`, causing `ArgumentError: too long unix socket path`
-  (max 104 bytes). The daemon crashed silently on startup. Fixed by falling back to
-  `/tmp` when `Dir.tmpdir` exceeds the socket path length limit.
+- **RBS Provider silently returning `Object` for all lookups:** `Provider` failed to load stdlib RBS libraries (
+  `socket`, `json`, etc.), causing `NoTypeFoundError` on any sig referencing stdlib types. All `signature_for` calls
+  fell back to inference which returned `Object`, silently breaking `docscribe update_types`.
+- **Unix socket path exceeding OS limit on macOS:** `Dir.tmpdir` returns a long path under `/var/folders/.../T`, causing
+  `ArgumentError: too long unix socket path` (max 104 bytes). The daemon crashed silently on startup. Fixed by falling
+  back to `/tmp` when `Dir.tmpdir` exceeds the socket path length limit.
 
 ### Changed
 
-- **`docscribe server status` now uses `ping` protocol** for extended info:
-  version, pid, socket path, uptime.
-- **Daemon auto-start no longer prints to stderr:** the `"Docscribe: starting server..."`
-  message is only emitted on explicit `docscribe server start`, not on implicit
-  auto-start via `--server`.
-- **README updated:** new Server mode section documenting daemon, thin client,
-  env invalidation, LRU cache, CLI override handling, ping protocol.
+- **`docscribe server status` now uses `ping` protocol** for extended info: version, pid, socket path, uptime.
+- **Daemon auto-start no longer prints to stderr:** the `"Docscribe: starting server..."` message is only emitted on
+  explicit `docscribe server start`, not on implicit auto-start via `--server`.
+- **README updated:** new Server mode section documenting daemon, thin client, env invalidation, LRU cache, CLI override
+  handling, ping protocol.
 - **Editor Integration section** updated to reference `docscribe-client` and daemon.
 
 ## 1.5.0

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# Docscribe
+<p align="center">
+  <img src="assets/icons/icon_128x128.png" alt="Docscribe logo" width="128">
+</p>
 
-[![Gem Version](https://img.shields.io/gem/v/docscribe.svg)](https://rubygems.org/gems/docscribe)
-[![RubyGems Downloads](https://img.shields.io/gem/dt/docscribe.svg)](https://rubygems.org/gems/docscribe)
-[![CI](https://github.com/unurgunite/docscribe/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/unurgunite/docscribe/actions/workflows/ci.yml)
-[![License](https://img.shields.io/github/license/unurgunite/docscribe.svg)](https://github.com/unurgunite/docscribe/blob/master/LICENSE.txt)
-[![Ruby](https://img.shields.io/badge/ruby-%3E%3D%202.7-blue.svg)](#installation)
-[![VS Code](https://img.shields.io/badge/VS%20Code-plugin-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=unurgunite.docscribe-vscode)
-[![RubyMine](https://img.shields.io/badge/RubyMine-plugin-green?logo=jetbrains)](https://plugins.jetbrains.com/plugin/32349-docscribe)
+<h1 align="center">DocScribe</h1>
 
-<p>
-  <img src="assets/icons/icon_256x256.png" alt="Docscribe logo" width="96">
+<p align="center">
+<a href="https://rubygems.org/gems/docscribe"><img src="https://img.shields.io/gem/v/docscribe.svg" alt="Gem Version"></a>
+<a href="https://rubygems.org/gems/docscribe"><img src="https://img.shields.io/gem/dt/docscribe.svg" alt="RubyGems Downloads"></a>
+<a href="https://github.com/unurgunite/docscribe/actions/workflows/ci.yml"><img src="https://github.com/unurgunite/docscribe/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI"></a>
+<a href="https://github.com/unurgunite/docscribe/blob/master/LICENSE.txt"><img src="https://img.shields.io/github/license/unurgunite/docscribe.svg" alt="License"></a>
+<a href="#installation"><img src="https://img.shields.io/badge/ruby-%3E%3D%202.7-blue.svg" alt="Ruby"></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=unurgunite.docscribe-vscode"><img src="https://img.shields.io/badge/VS%20Code-plugin-blue?logo=visualstudiocode" alt="VS Code"></a>
+<a href="https://plugins.jetbrains.com/plugin/32349-docscribe"><img src="https://img.shields.io/badge/RubyMine-plugin-green?logo=jetbrains" alt="RubyMine"></a>
 </p>
 
 ![Docscribe before/after demo](docs/image.png)
@@ -673,7 +675,7 @@ docscribe -a --server lib
 2. The socket path is derived from the project root, `Gemfile.lock` mtime, and `rbs_collection.lock.yaml` mtime — so any
    environment change spawns a fresh daemon automatically.
 3. Client requests (`docscribe --server`) send JSON-RPC 2.0 messages over the socket: `check` (inspect), `fix` (apply
-   changes), and `shutdown`.
+   changes), `shutdown`, and `ping` (health/version info).
 4. The daemon holds a reusable `Docscribe::Config` instance and an LRU file cache (bounded at 1000 entries), so repeated
    checks on the same files are nearly instant.
 5. After 5 minutes of inactivity the daemon shuts down automatically.
@@ -686,13 +688,19 @@ gem:
 
 ```shell
 # Check a file via the daemon
-docscribe-client check lib/user.rb
+docscribe-client --check lib/user.rb
 
 # Apply fixes via the daemon
-docscribe-client fix lib/user.rb
+docscribe-client --fix lib/user.rb
+
+# Check if the daemon is running
+docscribe-client --status
+
+# Get version, pid, uptime from the daemon
+docscribe-client --ping
 
 # Stop the daemon
-docscribe-client shutdown
+docscribe-client --shutdown
 ```
 
 The thin client is used automatically by

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -6,8 +6,13 @@ require 'socket'
 require 'json'
 require 'securerandom'
 require 'digest/md5'
+require 'tmpdir'
 
-SOCKET_DIR = '/tmp'
+SOCKET_DIR = begin
+  tmp = Dir.tmpdir || '/tmp'
+  sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize
+  tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
+end
 ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
 def socket_path(config_path = nil)
@@ -64,6 +69,7 @@ OptionParser.new do |opts|
   end
   opts.on('--shutdown', 'Shutdown the server') { mode = :shutdown }
   opts.on('--status', 'Show server status') { mode = :status }
+  opts.on('--ping', 'Ping the server') { mode = :ping }
 end.parse!
 
 sock = socket_path(config_path)
@@ -78,6 +84,9 @@ when :fix
 when :shutdown
   result = send_request(sock, 'shutdown')
   puts JSON.generate(result || { error: 'Connection failed' })
+when :ping
+  result = send_request(sock, 'ping')
+  puts JSON.generate(result || { error: 'Connection failed' })
 when :status
   alive = begin
     File.exist?(sock) &&
@@ -87,6 +96,6 @@ when :status
   end
   puts JSON.generate(alive ? { status: 'running', socket: sock } : { status: 'not_running' })
 else
-  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status"
+  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status | --ping"
   exit 1
 end

--- a/lib/docscribe/cli/server.rb
+++ b/lib/docscribe/cli/server.rb
@@ -95,16 +95,31 @@ module Docscribe
         # @return [Integer] exit code
         def show_status(config_path = nil)
           require 'docscribe/server'
+          return warn('Docscribe server is not running') || 0 unless Docscribe::Server.running?(config_path)
 
-          unless Docscribe::Server.running?(config_path)
-            warn 'Docscribe server is not running'
-            return 0
-          end
+          info = Docscribe::Server::Client.new(config_path: config_path).ping
+          info ? show_status_from_ping(info) : show_status_fallback(config_path)
+          0
+        end
 
+        # @private
+        # @param [Hash<String, Object>] info ping response hash
+        # @return [void]
+        def show_status_from_ping(info)
+          pid = info.dig('result', 'pid')
+          version = info.dig('result', 'version')
+          uptime = info.dig('result', 'uptime')
+          sock = info.dig('result', 'socket_path')
+          warn "Docscribe server v#{version} is running (pid #{pid}, socket #{sock}, uptime #{uptime}s)"
+        end
+
+        # @private
+        # @param [String?] config_path
+        # @return [void]
+        def show_status_fallback(config_path)
           pid = Docscribe::Server.read_pid(config_path)
           sock = Docscribe::Server.socket_path(config_path)
           warn "Docscribe server is running (pid #{pid}, socket #{sock})"
-          0
         end
 
         # Print usage information for the server subcommand.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -549,6 +549,7 @@ module Docscribe
       # @private
       # @param [UNIXSocket] client connected client socket
       # @param [String, Integer] id request ID
+      # @raise [StandardError] if ping response fails
       # @return [void]
       def handle_ping(client, id)
         uptime = (Time.now - @started_at).to_i
@@ -559,7 +560,7 @@ module Docscribe
                       'started_at' => @started_at.iso8601,
                       'uptime' => uptime
                     })
-      rescue => e
+      rescue StandardError => e
         send_error(client, id, -32_603, "handle_ping: #{e.class}: #{e.message} @started_at=#{@started_at.inspect}")
       end
 

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -5,6 +5,7 @@ require 'socket'
 require 'fileutils'
 require 'securerandom'
 require 'digest/md5'
+require 'tmpdir'
 require_relative 'lru_cache'
 
 module Docscribe
@@ -16,7 +17,14 @@ module Docscribe
   # - Auto-shutdown after idle timeout
   # - Protocol: JSON-RPC 2.0 over Unix socket
   module Server
-    SOCKET_DIR = '/tmp'
+    # Unix socket path max is 104 bytes on macOS (the more restrictive).
+    # Dir.tmpdir on macOS often returns a long path under /var/folders/.../T
+    # that exceeds this limit, so we fall back to /tmp when needed.
+    SOCKET_DIR = begin
+      tmp = Dir.tmpdir || '/tmp'
+      sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize # 80
+      tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
+    end
     IDLE_TIMEOUT = 300
 
     class << self
@@ -186,7 +194,7 @@ module Docscribe
       # @param [Boolean] daemonize
       # @return [void]
       def start_daemon_process(config_path:, daemonize:)
-        warn 'Docscribe: starting server...'
+        warn 'Docscribe: starting server...' if daemonize
         pid = Process.fork do # steep:ignore NoMethod
           [$stdin, $stdout].each { _1.reopen(File::NULL) }
           $stderr.reopen(File::NULL) if daemonize
@@ -240,38 +248,45 @@ module Docscribe
 
     # Client for communicating with a running Docscribe daemon.
     class Client
-      # @param [nil] socket_path custom socket path (defaults to server default)
-      # @param [nil] config_path optional config path for socket lookup
-      # @return [Object, nil]
+      # @param [String?] socket_path custom socket path (defaults to server default)
+      # @param [String?] config_path optional config path for socket lookup
+      # @return [void]
       def initialize(socket_path = nil, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
       end
 
       # Send a check request to the server.
       #
-      # @param [Object] file path to file to check
+      # @param [String] file path to file to check
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
-      # @param [Hash] rest
-      # @return [Object] response hash or nil if server unreachable
+      # @param [Object] rest
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def check(file:, strategy: :safe, **rest)
         request('check', file: file, strategy: strategy, **rest)
       end
 
       # Send a fix request to the server.
       #
-      # @param [Object] file path to file to fix
+      # @param [String] file path to file to fix
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
-      # @param [Hash] rest
-      # @return [Object] response hash or nil if server unreachable
+      # @param [Object] rest
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def fix(file:, strategy: :safe, **rest)
         request('fix', file: file, strategy: strategy, **rest)
       end
 
       # Send a shutdown request to the server.
       #
-      # @return [Object] response hash or nil if server unreachable
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def shutdown
         request('shutdown')
+      end
+
+      # Ping the server and get version/pid/uptime info.
+      #
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
+      def ping
+        request('ping')
       end
 
       private
@@ -279,9 +294,9 @@ module Docscribe
       # Send a JSON-RPC request and read the response.
       #
       # @private
-      # @param [Object] method method name
-      # @param [Hash] params request parameters
-      # @return [Object]
+      # @param [String] method method name
+      # @param [Object] params request parameters
+      # @return [Hash<String, Object>?]
       def request(method, **params)
         connect do |socket|
           req = Protocol.build_request(method, params)
@@ -299,7 +314,7 @@ module Docscribe
       # @private
       # @raise [Errno::ECONNREFUSED]
       # @raise [Errno::ENOENT]
-      # @return [Object?, Object] yield return value or nil on connection error
+      # @return [T?] yield return value or nil on connection error
       def connect
         socket = UNIXSocket.new(@socket_path)
         yield socket
@@ -312,10 +327,10 @@ module Docscribe
 
     # Daemon process that loads the Ruby runtime once and serves requests.
     class Daemon
-      # @param [nil] socket_path custom socket path
-      # @param [IDLE_TIMEOUT] idle_timeout seconds before automatic shutdown
-      # @param [nil] config_path custom config path
-      # @return [LRUCache]
+      # @param [String?] socket_path custom socket path
+      # @param [Integer] idle_timeout seconds before automatic shutdown
+      # @param [String?] config_path custom config path
+      # @return [void]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
@@ -324,11 +339,12 @@ module Docscribe
         @running = false
         @server = nil
         @file_cache = LRUCache.new
+        @started_at = Time.now
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.
       #
-      # @return [Object]
+      # @return [void]
       def start
         load_dependencies
         setup_socket
@@ -343,7 +359,7 @@ module Docscribe
       # Load the full Docscribe runtime and build cached config.
       #
       # @private
-      # @return [Object]
+      # @return [void]
       def load_dependencies
         require 'docscribe'
         @config = Docscribe::Config.load(@config_path)
@@ -354,7 +370,7 @@ module Docscribe
       # Create and bind the Unix domain socket.
       #
       # @private
-      # @return [Object]
+      # @return [void]
       def setup_socket
         FileUtils.rm_f(@socket_path)
         FileUtils.mkdir_p(File.dirname(@socket_path))
@@ -363,7 +379,7 @@ module Docscribe
       end
 
       # @private
-      # @return [Object]
+      # @return [void]
       def write_pid
         File.write("#{@socket_path}.pid", Process.pid)
       end
@@ -372,7 +388,7 @@ module Docscribe
       #
       # @private
       # @raise [Interrupt]
-      # @return [Object, Boolean, Object]
+      # @return [void]
       def listen_loop
         while @running
           check_idle_timeout
@@ -387,7 +403,7 @@ module Docscribe
       # Check whether the idle timeout has been exceeded.
       #
       # @private
-      # @return [Boolean?]
+      # @return [void]
       def check_idle_timeout
         elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_request_time
         @running = false if elapsed > @idle_timeout
@@ -396,7 +412,7 @@ module Docscribe
       # Accept a client connection if one is available.
       #
       # @private
-      # @return [Object]
+      # @return [void]
       def accept_client
         client = @server&.accept if @server&.wait_readable(1)
         return unless client
@@ -408,9 +424,9 @@ module Docscribe
       # Read a request from a client connection and dispatch it.
       #
       # @private
-      # @param [Object] client connected client socket
+      # @param [UNIXSocket] client connected client socket
       # @raise [StandardError]
-      # @return [Object]
+      # @return [void]
       def handle_client(client)
         request_line = client.gets or return
         request = Protocol.parse_response(request_line)
@@ -424,9 +440,9 @@ module Docscribe
       # Dispatch a parsed request to the appropriate handler.
       #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] request parsed JSON-RPC request
-      # @return [Object]
+      # @param [UNIXSocket] client connected client socket
+      # @param [Hash<String, Object>] request parsed JSON-RPC request
+      # @return [void]
       def handle_request(client, request)
         method = request['method']
         params = request['params'] || {}
@@ -435,15 +451,16 @@ module Docscribe
         when 'check' then handle_check(client, request['id'], params)
         when 'fix' then handle_fix(client, request['id'], params)
         when 'shutdown' then handle_shutdown(client, request['id'])
+        when 'ping' then handle_ping(client, request['id'])
         else send_error(client, request['id'], -32_601, "Unknown method: #{method}")
         end
       end
 
       # @private
-      # @param [Object] client
-      # @param [Object] id
-      # @param [Object] params
-      # @return [Object]
+      # @param [UNIXSocket] client
+      # @param [String, Integer] id
+      # @param [Hash<String, Object>] params
+      # @return [void]
       def handle_check(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -456,10 +473,10 @@ module Docscribe
       end
 
       # @private
-      # @param [Object] client
-      # @param [Object] id
-      # @param [Object] params
-      # @return [Object]
+      # @param [UNIXSocket] client
+      # @param [String, Integer] id
+      # @param [Hash<String, Object>] params
+      # @return [void]
       def handle_fix(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -473,8 +490,8 @@ module Docscribe
       end
 
       # @private
-      # @param [Object] overrides
-      # @return [Object]
+      # @param [Hash<String, Object>?] overrides
+      # @return [void]
       def apply_cli_overrides(overrides)
         return reset_effective_config if overrides.nil? || overrides.empty?
         return if @applied_overrides == overrides
@@ -488,7 +505,7 @@ module Docscribe
       end
 
       # @private
-      # @return [Object]
+      # @return [void]
       def reset_effective_config
         return unless @effective_config
 
@@ -498,10 +515,10 @@ module Docscribe
       end
 
       # @private
-      # @param [Object] file
-      # @param [Object] strategy
+      # @param [String] file
+      # @param [Symbol] strategy
       # @raise [StandardError]
-      # @return [Array]
+      # @return [(String, Hash<Symbol, Object>)]
       def rewrite_file(file, strategy)
         config = @effective_config || @config or raise 'Docscribe: config not loaded'
         key = [file, strategy]
@@ -519,32 +536,49 @@ module Docscribe
       # Handle a shutdown request.
       #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @return [Boolean]
+      # @param [UNIXSocket] client connected client socket
+      # @param [String, Integer] id request ID
+      # @return [void]
       def handle_shutdown(client, id)
         send_result(client, id, { 'status' => 'shutting_down' })
         @running = false
       end
 
+      # Handle a ping request.
+      #
+      # @private
+      # @param [UNIXSocket] client connected client socket
+      # @param [String, Integer] id request ID
+      # @return [void]
+      def handle_ping(client, id)
+        uptime = (Time.now - @started_at).to_i
+        send_result(client, id, {
+                      'version' => Docscribe::VERSION,
+                      'pid' => Process.pid,
+                      'socket_path' => @socket_path,
+                      'started_at' => @started_at.iso8601,
+                      'uptime' => uptime
+                    })
+      end
+
       # Send a JSON-RPC result response.
       #
       # @private
-      # @param [Object] client connected client socket
-      # @param [Object] id request ID
-      # @param [Object] result result data
-      # @return [Object]
+      # @param [UNIXSocket] client connected client socket
+      # @param [String, Integer] id request ID
+      # @param [Hash<String, Object>] result result data
+      # @return [void]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }
         client.write(Protocol.serialize(response))
       end
 
       # @private
-      # @param [Object] client
-      # @param [Object] id
-      # @param [Object] code
-      # @param [Object] message
-      # @return [Object]
+      # @param [UNIXSocket] client
+      # @param [String, Integer, nil] id
+      # @param [Integer] code
+      # @param [String] message
+      # @return [void]
       def send_error(client, id, code, message)
         response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
         client.write(Protocol.serialize(response))
@@ -554,7 +588,7 @@ module Docscribe
       #
       # @private
       # @raise [StandardError]
-      # @return [Object]
+      # @return [void]
       # @return [nil] if StandardError
       def cleanup
         @server&.close

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -559,6 +559,8 @@ module Docscribe
                       'started_at' => @started_at.iso8601,
                       'uptime' => uptime
                     })
+      rescue => e
+        send_error(client, id, -32_603, "handle_ping: #{e.class}: #{e.message} @started_at=#{@started_at.inspect}")
       end
 
       # Send a JSON-RPC result response.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'securerandom'
 require 'digest/md5'
 require 'tmpdir'
+require 'time'
 require_relative 'lru_cache'
 
 module Docscribe
@@ -549,7 +550,6 @@ module Docscribe
       # @private
       # @param [UNIXSocket] client connected client socket
       # @param [String, Integer] id request ID
-      # @raise [StandardError] if ping response fails
       # @return [void]
       def handle_ping(client, id)
         uptime = (Time.now - @started_at).to_i
@@ -560,8 +560,6 @@ module Docscribe
                       'started_at' => @started_at.iso8601,
                       'uptime' => uptime
                     })
-      rescue StandardError => e
-        send_error(client, id, -32_603, "handle_ping: #{e.class}: #{e.message} @started_at=#{@started_at.inspect}")
       end
 
       # Send a JSON-RPC result response.

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'yaml'
 require 'docscribe/types/signature'
 require 'docscribe/types/rbs/type_formatter'
 require 'docscribe/types/rbs/collection_loader'
@@ -132,6 +133,7 @@ module Docscribe
         def build_env_with_collection(all_dirs, collection_dirs)
           loader = ::RBS::EnvironmentLoader.new
           loader.add(library: 'rbs') # steep:ignore
+          load_stdlib_libraries!(loader)
           add_dirs_to_loader!(loader, all_dirs, collection_dirs)
           env = ::RBS::Environment.from_loader(loader).resolve_type_names
           @builder = ::RBS::DefinitionBuilder.new(env: env)
@@ -197,6 +199,7 @@ module Docscribe
         def build_env(dirs)
           loader = ::RBS::EnvironmentLoader.new
           loader.add(library: 'rbs') # steep:ignore
+          load_stdlib_libraries!(loader)
 
           dirs.each do |dir|
             path = Pathname(dir)
@@ -206,6 +209,31 @@ module Docscribe
           env = ::RBS::Environment.from_loader(loader).resolve_type_names
           @builder = ::RBS::DefinitionBuilder.new(env: env)
           env
+        end
+
+        # Load stdlib RBS libraries declared in rbs_collection.lock.yaml.
+        #
+        # Without this, RBS types defined in user sig/ files (e.g. UNIXSocket)
+        # fail to resolve and the entire RBS environment breaks, causing all
+        # type lookups to silently fall back to inference.
+        #
+        # @private
+        # @param [RBS::EnvironmentLoader] loader
+        # @raise [StandardError]
+        # @return [void]
+        # @return [nil] if StandardError
+        def load_stdlib_libraries!(loader)
+          lock_path = File.join(Dir.pwd, 'rbs_collection.lock.yaml')
+          return unless File.exist?(lock_path)
+
+          lock = YAML.safe_load_file(lock_path) # steep:ignore
+          (lock['gems'] || []).each do |gem|
+            next unless gem['source'] && gem['source']['type'] == 'stdlib'
+
+            loader.add(library: gem['name']) # steep:ignore
+          end
+        rescue StandardError => e
+          warn "Docscribe: Failed to load stdlib RBS libraries: #{e.message}"
         end
 
         # Build the appropriate instance or singleton definition for a container.

--- a/sig/lib/docscribe/cli/server.rbs
+++ b/sig/lib/docscribe/cli/server.rbs
@@ -6,6 +6,8 @@ module Docscribe
       def self?.start_server: (?String? config_path) -> Integer
       def self?.stop_server: (?String? config_path) -> Integer
       def self?.show_status: (?String? config_path) -> Integer
+      def self?.show_status_from_ping: (Hash[String, untyped] info) -> void
+      def self?.show_status_fallback: (String? config_path) -> void
       def self?.already_running: (?String? config_path) -> Integer
       def self?.parse_args: (Array[String] argv) -> [ String?, String? ]
       def self?.usage: () -> String

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -1,3 +1,7 @@
+class Dir
+  def self?.tmpdir: () -> String
+end
+
 module Docscribe
   module Server
     SOCKET_DIR: String
@@ -31,6 +35,7 @@ module Docscribe
       def fix: (file: String, ?strategy: Symbol, **untyped) -> Hash[String, untyped]?
 
       def shutdown: () -> Hash[String, untyped]?
+      def ping: () -> Hash[String, untyped]?
 
       private
 
@@ -49,6 +54,7 @@ module Docscribe
       @core_rbs_provider: untyped
       @file_cache: Docscribe::LRUCache
       @effective_config: Docscribe::Config?
+      @started_at: Time
       @applied_overrides: Hash[String, untyped]?
 
       def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
@@ -70,6 +76,7 @@ module Docscribe
       def reset_effective_config: () -> void
       def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
+      def handle_ping: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def send_error: (UNIXSocket, (String | Integer | nil), Integer, String) -> void
       def cleanup: () -> void

--- a/sig/lib/docscribe/types/rbs/provider.rbs
+++ b/sig/lib/docscribe/types/rbs/provider.rbs
@@ -39,6 +39,7 @@ module Docscribe
         def add_collection_gem_dirs: (::RBS::EnvironmentLoader loader, Pathname path, Array[String] stdlib) -> void
 
         def stdlib_gem_names: -> Array[String]
+        def load_stdlib_libraries!: (::RBS::EnvironmentLoader loader) -> void
 
         def definition_for: (container: String, scope: Symbol) -> (::RBS::Definition | nil)
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Docscribe::Server do
   include ServerWireHelper
 
   describe '.socket_path' do
-    it 'returns a path under /tmp' do
-      expect(described_class.socket_path).to match(%r{\A/tmp/docscribe-})
+    it 'returns a path under tmpdir' do
+      expect(described_class.socket_path).to match(%r{\A(?:#{Regexp.escape(Dir.tmpdir)}|/tmp)/docscribe-})
     end
 
     it 'includes an MD5 of the working directory' do
@@ -151,7 +151,7 @@ RSpec.describe Docscribe::Server do
     after { FileUtils.rm_rf(dir) }
 
     it 'returns false when socket does not exist' do
-      allow(described_class).to receive(:socket_path).and_return('/tmp/nonexistent.sock')
+      allow(described_class).to receive(:socket_path).and_return("#{Dir.tmpdir}/nonexistent.sock")
       expect(described_class.running?).to be false
     end
 
@@ -243,6 +243,12 @@ RSpec.describe Docscribe::Server do
     describe '#shutdown' do
       it 'returns nil when server is unreachable' do
         expect(client.shutdown).to be_nil
+      end
+    end
+
+    describe '#ping' do
+      it 'returns nil when server is unreachable' do
+        expect(client.ping).to be_nil
       end
     end
 
@@ -351,6 +357,36 @@ RSpec.describe Docscribe::Server do
         client.shutdown
         sleep 0.3
         expect(File.exist?(socket_path)).to be false
+      end
+    end
+
+    describe 'ping request' do
+      def ping_response
+        client.ping
+      end
+
+      it 'responds to ping' do
+        expect(ping_response).not_to be_nil
+      end
+
+      it 'returns version' do
+        expect(ping_response.dig('result', 'version')).to eq(Docscribe::VERSION)
+      end
+
+      it 'returns pid' do
+        expect(ping_response.dig('result', 'pid')).to eq(Process.pid)
+      end
+
+      it 'returns socket_path' do
+        expect(ping_response.dig('result', 'socket_path')).to eq(socket_path)
+      end
+
+      it 'returns started_at as an ISO8601 string' do
+        expect(ping_response.dig('result', 'started_at')).to be_a(String)
+      end
+
+      it 'returns uptime as an integer' do
+        expect(ping_response.dig('result', 'uptime')).to be_a(Integer)
       end
     end
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -370,8 +370,7 @@ RSpec.describe Docscribe::Server do
       end
 
       it 'returns version' do
-        resp = ping_response
-        expect(resp.dig('result', 'version')).to eq(Docscribe::VERSION), "ping_response=#{resp.inspect}"
+        expect(ping_response.dig('result', 'version')).to eq(Docscribe::VERSION)
       end
 
       it 'returns pid' do

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -370,7 +370,8 @@ RSpec.describe Docscribe::Server do
       end
 
       it 'returns version' do
-        expect(ping_response.dig('result', 'version')).to eq(Docscribe::VERSION)
+        resp = ping_response
+        expect(resp.dig('result', 'version')).to eq(Docscribe::VERSION), "ping_response=#{resp.inspect}"
       end
 
       it 'returns pid' do


### PR DESCRIPTION
## Summary

Three server/daemon polish items, two critical bugfixes, and documentation updates.

## Changes

### Polish items

- **`Dir.tmpdir` with socket path fallback** — `SOCKET_DIR` now uses `Dir.tmpdir` for portability, with automatic fallback to `/tmp` when the computed Unix socket path exceeds the OS limit (104 bytes on macOS). Fixes `ArgumentError: too long unix socket path` on systems where `Dir.tmpdir` returns a long path (e.g. macOS `/var/folders/.../T` at 56+ chars).
- **`ping` endpoint** — `Client#ping` and `Daemon#handle_ping` return version, pid, socket path, started_at, and uptime. `docscribe-client --ping` queries daemon health. `docscribe server status` now uses the ping protocol for extended info (falling back to legacy pid file read if the daemon doesn't support ping).
- **Suppress `warn` on auto-start** — The "Docscribe: starting server..." message is only emitted on explicit `docscribe server start`. Auto-start via `docscribe --server` (or `docscribe-client`) starts silently.

### Bugfixes

- **RBS Provider not loading stdlib from `rbs_collection.lock.yaml`** — `Provider#build_env_with_collection` and `build_env` did not load stdlib libraries (`socket`, `json`, `digest`, etc.) declared in `rbs_collection.lock.yaml`. All `signature_for` calls raised `NoTypeFoundError`, causing type resolution to silently fall back to `Object`. Added `load_stdlib_libraries!` which parses the lock file and calls `loader.add(library: name)` for each stdlib dependency. This fixes `docscribe update_types` producing `@return [Object]` instead of the correct type.

- **Unix socket path exceeds OS limit on macOS** — `Dir.tmpdir` returns paths under `/var/folders/.../T` (~56 chars) that, combined with the socket filename, exceed the 104-byte `sun_path` limit. Daemon crashed on startup with `ArgumentError`. `SOCKET_DIR` now dynamically checks the projected path length and falls back to `/tmp` when necessary.

### Documentation

- **CHANGELOG.md** — Added entries for all new features, bugfixes, and behavioral changes.
- **README.md** — Updated badges section from markdown to pure HTML format. Server mode documentation updated to mention `ping` protocol and `--status`/`--ping` flags for `docscribe-client`.

## Verification

- `bundle exec rspec` — 1034 examples, 0 failures, 3 pending
- `bundle exec rubocop` — 0 offenses
- `bundle exec steep check` — no type errors