### PR TITLE
[1.5.1] Shorten socket path hash, resilient stdlib loading

### DIFF
--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -10,16 +10,20 @@ require 'tmpdir'
 
 SOCKET_DIR = begin
   tmp = Dir.tmpdir || '/tmp'
-  sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize
+  sock_overhead = "/docscribe-#{'a' * 32}.sock".bytesize
   tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
 end
 ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
 def socket_path(config_path = nil)
-  hash = Digest::MD5.hexdigest(Dir.pwd)
-  env_seed = env_hash
-  suffix = config_path ? "-#{config_hash(config_path)}" : ''
-  "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+  seed = +Dir.pwd
+  seed << ":#{env_hash}"
+  if config_path
+    resolved = File.expand_path(config_path)
+    mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+    seed << ":#{resolved}:#{mtime}"
+  end
+  "#{SOCKET_DIR}/docscribe-#{Digest::MD5.hexdigest(seed)}.sock"
 end
 
 def env_hash

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -23,7 +23,7 @@ module Docscribe
     # that exceeds this limit, so we fall back to /tmp when needed.
     SOCKET_DIR = begin
       tmp = Dir.tmpdir || '/tmp'
-      sock_overhead = "/docscribe-#{'a' * 64}.sock".bytesize # 80
+      sock_overhead = "/docscribe-#{'a' * 32}.sock".bytesize # 48
       tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
     end
     IDLE_TIMEOUT = 300
@@ -163,10 +163,14 @@ module Docscribe
       # @param [String?] config_path optional config path to differentiate
       # @return [String]
       def socket_path(config_path = nil)
-        hash = Digest::MD5.hexdigest(Dir.pwd)
-        env_seed = env_hash
-        suffix = config_path ? "-#{config_hash(config_path)}" : ''
-        "#{SOCKET_DIR}/docscribe-#{hash}#{suffix}#{env_seed}.sock"
+        seed = +Dir.pwd
+        seed << ":#{env_hash}"
+        if config_path
+          resolved = File.expand_path(config_path)
+          mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+          seed << ":#{resolved}:#{mtime}"
+        end
+        "#{SOCKET_DIR}/docscribe-#{Digest::MD5.hexdigest(seed)}.sock"
       end
 
       # @param [String] config_path

--- a/lib/docscribe/types/rbs/provider.rb
+++ b/lib/docscribe/types/rbs/provider.rb
@@ -227,13 +227,25 @@ module Docscribe
           return unless File.exist?(lock_path)
 
           lock = YAML.safe_load_file(lock_path) # steep:ignore
-          (lock['gems'] || []).each do |gem|
-            next unless gem['source'] && gem['source']['type'] == 'stdlib'
-
-            loader.add(library: gem['name']) # steep:ignore
-          end
+          (lock['gems'] || []).each { |gem| add_stdlib_gem(loader, gem) }
         rescue StandardError => e
-          warn "Docscribe: Failed to load stdlib RBS libraries: #{e.message}"
+          warn "Docscribe: Failed to parse rbs_collection.lock.yaml: #{e.message}"
+        end
+
+        # Add a single stdlib gem from the lock file to the loader.
+        #
+        # @private
+        # @param [RBS::EnvironmentLoader] loader
+        # @param [Object] gem gem entry from rbs_collection.lock.yaml
+        # @raise [StandardError]
+        # @return [void]
+        # @return [nil] if StandardError
+        def add_stdlib_gem(loader, gem)
+          return unless gem.is_a?(Hash) && gem.dig('source', 'type') == 'stdlib'
+
+          loader.add(library: gem['name']) # steep:ignore
+        rescue StandardError => e
+          warn "Docscribe: Failed to load stdlib RBS library '#{gem['name']}': #{e.message}"
         end
 
         # Build the appropriate instance or singleton definition for a container.

--- a/sig/lib/docscribe/types/rbs/provider.rbs
+++ b/sig/lib/docscribe/types/rbs/provider.rbs
@@ -39,7 +39,10 @@ module Docscribe
         def add_collection_gem_dirs: (::RBS::EnvironmentLoader loader, Pathname path, Array[String] stdlib) -> void
 
         def stdlib_gem_names: -> Array[String]
+
         def load_stdlib_libraries!: (::RBS::EnvironmentLoader loader) -> void
+
+        def add_stdlib_gem: (::RBS::EnvironmentLoader loader, untyped gem) -> void
 
         def definition_for: (container: String, scope: Symbol) -> (::RBS::Definition | nil)
 

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Docscribe::Server do
     end
 
     it 'includes an MD5 of the working directory' do
-      hash_segment = Digest::MD5.hexdigest(Dir.pwd)
+      seed = +Dir.pwd
+      seed << ":#{described_class.send(:env_hash)}"
+      hash_segment = Digest::MD5.hexdigest(seed)
       expect(described_class.socket_path).to include(hash_segment)
     end
 


### PR DESCRIPTION

## Summary

Two socket path now uses a single MD5 hash (safe under macOS 104-byte limit even with `config_path`), and `load_stdlib_libraries!` is resilient to individual gem loading failures.

## Changes

- **`socket_path` now uses a single MD5 digest** of all seed components (`Dir.pwd`, `env_hash`, `config_path + mtime`) instead of concatenating three separate hashes. Filename is always `docscribe-{32 hex chars}.sock` (47 bytes) regardless of `config_path`. Together with the `/tmp` fallback the total path is ~52 bytes — well within macOS's 104-byte `sun_path` limit.
- **`SOCKET_DIR` overhead updated** from 80 to 48 bytes to match the new 32-char hash.
- **`load_stdlib_libraries!`** per-iteration rescue so one failing `loader.add` doesn't block remaining stdlib libraries. Added `gem.is_a?(Hash)` guard before accessing `gem['source']`.
- **`add_stdlib_gem` extracted** from `load_stdlib_libraries!` to satisfy Metrics/AbcSize and CyclomaticComplexity limits.
- **RBS signature** added for `add_stdlib_gem`.
- **Test updated** to match new hash computation.

## Verification

- [x] `bundle exec rspec` — 1034 examples, 0 failures
- [x] `bundle exec rubocop` — 0 offenses in 208 files
- [x] `bundle exec steep check` — no type errors