### PR TITLE
[1.5.1] Fixed server

### DIFF
--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -37,13 +37,13 @@ module Docscribe
       # @raise [StandardError]
       # @return [void]
       def ensure_running!(config_path: nil, daemonize: false, timeout: 5)
-        return if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
+        return if running?(config_path)
         raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
 
         lock_path = "#{socket_path(config_path)}.lock"
         File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
           lock.flock(File::LOCK_EX)
-          next if wait_for_ready(config_path: config_path, timeout: 0, raise_on_timeout: false)
+          next if running?(config_path)
 
           start_daemon_process(config_path: config_path, daemonize: daemonize)
         end
@@ -57,7 +57,7 @@ module Docscribe
       # @param [Boolean] raise_on_timeout
       # @raise [StandardError]
       # @return [Boolean]
-      def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true)
+      def wait_for_ready(config_path: nil, timeout: 5, raise_on_timeout: true) # rubocop:disable SortedMethodsByCall/Waterfall
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         loop do
           return true if running?(config_path)
@@ -193,6 +193,8 @@ module Docscribe
         Digest::MD5.hexdigest(parts.join(':'))
       end
 
+      public :read_pid, :pid_path, :socket_path
+
       # @param [String?] config_path
       # @param [Boolean] daemonize
       # @return [void]
@@ -200,13 +202,11 @@ module Docscribe
         warn 'Docscribe: starting server...' if daemonize
         pid = Process.fork do # steep:ignore NoMethod
           [$stdin, $stdout].each { _1.reopen(File::NULL) }
-          $stderr.reopen(File::NULL) if daemonize
+          $stderr.reopen(File::NULL)
           Daemon.new(config_path: config_path).start
         end
         Process.detach(pid)
       end
-
-      public :read_pid, :pid_path, :socket_path
     end
 
     # JSON-line protocol helpers.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -193,8 +193,6 @@ module Docscribe
         Digest::MD5.hexdigest(parts.join(':'))
       end
 
-      public :read_pid, :pid_path, :socket_path
-
       # @param [String?] config_path
       # @param [Boolean] daemonize
       # @return [void]
@@ -207,6 +205,8 @@ module Docscribe
         end
         Process.detach(pid)
       end
+
+      public :read_pid, :pid_path, :socket_path
     end
 
     # JSON-line protocol helpers.


### PR DESCRIPTION
## Summary

Suppressed spurious `warn()` on every client startup and fixed a stderr pipe leak that blocks IDE plugins when `daemonize: false`.

## Changes

- **`ensure_running!`** — calls `running?` instead of `wait_for_ready(timeout: 0, raise_on_timeout: false)` for the two quick checks before acquiring the lock. With a zero deadline, `wait_for_ready` immediately prints `warn("Docscribe server failed to start within timeout")` to stderr on every startup — even when the daemon starts successfully a moment later. `running?` probes the socket directly with no timeout and no warning.

- **`start_daemon_process`** — `$stderr.reopen(File::NULL)` is now unconditional (removed `if daemonize`). When `daemonize: false` (RubyMine plugin), the forked daemon inherits the parent's stderr pipe. The parent exits but the daemon keeps the write-end open, blocking the plugin's `readText()` forever.

## Verification

- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)