### PR TITLE
[1.5.2] Client tooling: socket-path, info, ensure (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,7 +648,8 @@ Exit code `0` if no placeholders found, `1` if any are detected.
 ### `docscribe server` — persistent daemon mode
 
 > [!NOTE]
-> Server mode requires **Ruby 3.1+** (`Process.fork` for background daemon).
+> Server mode requires **Ruby 3.1+** and a platform with `Process.fork` and Unix domain sockets.
+> Not available on **Windows** (no Unix sockets) or **JRuby** (no `Process.fork`).
 
 `docscribe server` starts a background daemon that keeps the Ruby runtime loaded and caches parsed ASTs across
 invocations. Subsequent `docscribe` calls with `--server` communicate with the daemon over a Unix socket instead of
@@ -703,6 +704,25 @@ docscribe-client --ping
 docscribe-client --shutdown
 ```
 
+Additional thin client commands:
+
+```shell
+# Print the Unix socket path (for IDE plugin integration)
+docscribe-client --socket-path
+
+# Show server info: version, pid, uptime, config path
+docscribe-client --info
+
+# Auto-start the daemon before running a check or fix
+docscribe-client --ensure --check lib/user.rb
+
+# Start the daemon standalone (exits when ready)
+docscribe-client --ensure
+
+# Batch check multiple files in one RPC call
+docscribe-client --check-batch lib/a.rb,lib/b.rb,lib/c.rb
+```
+
 The thin client is used automatically by
 the [VS Code](https://marketplace.visualstudio.com/items?itemName=unurgunite.docscribe-vscode)
 and [RubyMine](https://plugins.jetbrains.com/plugin/32349-docscribe) plugins when the daemon is running.
@@ -716,6 +736,41 @@ The daemon's socket path includes a hash of:
 
 If any of these files change, the next `docscribe --server` call will start a new daemon automatically. The old daemon
 is left to idle-timeout on its own.
+
+**JSON-RPC protocol (semi-stable API):**
+
+The daemon speaks JSON-RPC 2.0 over Unix socket. Each request is a JSON line, each response is a JSON line.
+
+Methods:
+
+| Method | Parameters | Result |
+|--------|-----------|--------|
+| `check` | `file` (string), `strategy` ("safe"/"aggressive"), `cli_overrides` (hash, optional) | `status`, `changed`, `changes` |
+| `fix` | same as `check` | `status`, `changed`, `changes` |
+| `check_batch` | `files` (array of strings), `strategy`, `cli_overrides`, `timeout` (int, optional) | array of per-file results |
+| `ping` | — | `version`, `pid`, `socket_path`, `started_at`, `uptime` |
+| `shutdown` | — | `status` |
+
+Error codes (standardized for IDE plugin integration):
+
+| Code | Meaning | `error.data` fields |
+|------|---------|-------------------|
+| `-32000` | Gem/dependency not found | `gem` |
+| `-32001` | Syntax error in analyzed file | `file`, `line`, `detail` |
+| `-32002` | Config load failure | — |
+| `-32010` | Timeout | `timeout`, `file` |
+| `-32099` | Internal unhandled error | `backtrace` (first 5 lines) |
+
+**Socket path derivation:**
+
+The socket path is a deterministic hash of:
+- Working directory (`Dir.pwd`)
+- `Gemfile.lock` mtime and `rbs_collection.lock.yaml` mtime (environment invalidation)
+- Config file path and mtime (when `--config` is used)
+
+Result: `/tmp/docscribe-<MD5 hash>.sock`
+
+IDE plugins should use `docscribe-client --socket-path` instead of reimplementing this algorithm.
 
 **CLI override handling:**
 

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -61,6 +61,8 @@ config_path = nil
 mode = nil
 file = nil
 ensure_flag = false
+batch_files = nil
+batch_timeout = nil
 
 OptionParser.new do |opts|
   opts.on('-C', '--config <path>', 'Config file path') { |v| config_path = v }
@@ -72,6 +74,11 @@ OptionParser.new do |opts|
     mode = :fix
     file = v
   end
+  opts.on('--check-batch <files>', 'Check multiple files (comma-separated)') do |v|
+    mode = :check_batch
+    batch_files = v
+  end
+  opts.on('--timeout <seconds>', 'Timeout per file in batch mode') { |v| batch_timeout = v.to_f }
   opts.on('--shutdown', 'Shutdown the server') { mode = :shutdown }
   opts.on('--status', 'Show server status') { mode = :status }
   opts.on('--ping', 'Ping the server') { mode = :ping }
@@ -120,6 +127,12 @@ when :check
 when :fix
   result = send_request(sock, 'fix', file: file, strategy: :safe)
   puts JSON.generate(result || { error: 'Connection failed' })
+when :check_batch
+  files = batch_files.split(',').map(&:strip)
+  params = { files: files, strategy: :safe }
+  params[:timeout] = batch_timeout if batch_timeout
+  result = send_request(sock, 'check_batch', **params)
+  puts JSON.generate(result || { error: 'Connection failed' })
 when :shutdown
   result = send_request(sock, 'shutdown')
   puts JSON.generate(result || { error: 'Connection failed' })
@@ -135,6 +148,6 @@ when :status
   end
   puts JSON.generate(alive ? { status: 'running', socket: sock } : { status: 'not_running' })
 else
-  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status | --ping | --socket-path | --info | --ensure"
+  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --check-batch <files> | --shutdown | --status | --ping | --socket-path | --info | --ensure"
   exit 1
 end

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -60,6 +60,7 @@ end
 config_path = nil
 mode = nil
 file = nil
+ensure_flag = false
 
 OptionParser.new do |opts|
   opts.on('-C', '--config <path>', 'Config file path') { |v| config_path = v }
@@ -74,11 +75,45 @@ OptionParser.new do |opts|
   opts.on('--shutdown', 'Shutdown the server') { mode = :shutdown }
   opts.on('--status', 'Show server status') { mode = :status }
   opts.on('--ping', 'Ping the server') { mode = :ping }
+  opts.on('--socket-path', 'Print socket path and exit') { mode = :socket_path }
+  opts.on('--info', 'Show server info') { mode = :info }
+  opts.on('--ensure', 'Ensure server is running before check/fix') { ensure_flag = true }
 end.parse!
 
 sock = socket_path(config_path)
 
+if ensure_flag && mode.nil?
+  require 'docscribe/server'
+  Docscribe::Server.ensure_running!(config_path: config_path)
+  exit 0
+end
+
+if ensure_flag && %i[check fix].include?(mode)
+  begin
+    UNIXSocket.new(sock).close
+  rescue Errno::ECONNREFUSED, Errno::ENOENT
+    require 'docscribe/server'
+    Docscribe::Server.ensure_running!(config_path: config_path)
+  rescue StandardError => e
+    warn "docscribe: #{e.message}"
+    exit 1
+  end
+end
+
 case mode
+when :socket_path
+  puts sock
+when :info
+  result = send_request(sock, 'ping')
+  if result && result['result']
+    info = result['result']
+    info['status'] = 'running'
+    info['config_path'] = config_path if config_path
+    info['cli_overrides'] = {}
+    puts JSON.generate(info)
+  else
+    puts JSON.generate({ status: 'not_running', socket_path: sock })
+  end
 when :check
   result = send_request(sock, 'check', file: file, strategy: :safe)
   puts JSON.generate(result || { error: 'Connection failed' })
@@ -100,6 +135,6 @@ when :status
   end
   puts JSON.generate(alive ? { status: 'running', socket: sock } : { status: 'not_running' })
 else
-  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status | --ping"
+  warn "Usage: #{$PROGRAM_NAME} --check <file> | --fix <file> | --shutdown | --status | --ping | --socket-path | --info | --ensure"
   exit 1
 end

--- a/lib/docscribe/cli/rbs_gen.rb
+++ b/lib/docscribe/cli/rbs_gen.rb
@@ -167,7 +167,7 @@ module Docscribe
         # @return [Boolean] if StandardError
         def generate_for_file(path, options)
           process_source?(File.read(path), path, options)
-        rescue Parser::SyntaxError => e # steep:ignore
+        rescue Parser::SyntaxError => e
           warn "Syntax error in #{path}: #{e.message}"
           false
         rescue StandardError => e

--- a/lib/docscribe/cli/sigs.rb
+++ b/lib/docscribe/cli/sigs.rb
@@ -169,7 +169,7 @@ module Docscribe
           return unless ast
 
           walk_for_methods(ast, [], methods, path)
-        rescue Parser::SyntaxError => e # steep:ignore
+        rescue Parser::SyntaxError => e
           warn "Syntax error in #{path}: #{e.message}"
         rescue StandardError => e
           warn "Error parsing #{path}: #{e.class}: #{e.message}"

--- a/lib/docscribe/infer/params.rb
+++ b/lib/docscribe/infer/params.rb
@@ -98,7 +98,7 @@ module Docscribe
         buffer = Parser::Source::Buffer.new('(param)')
         buffer.source = src
         Docscribe::Parsing.parse_buffer(buffer)
-      rescue Parser::SyntaxError # steep:ignore
+      rescue Parser::SyntaxError
         nil
       end
     end

--- a/lib/docscribe/infer/returns.rb
+++ b/lib/docscribe/infer/returns.rb
@@ -26,7 +26,7 @@ module Docscribe
         local_var_types = build_local_variable_types(body)
         run_last_expr_type(body, fallback_type: FALLBACK_TYPE, nil_as_optional: true,
                                  local_var_types: local_var_types) || FALLBACK_TYPE
-      rescue Parser::SyntaxError # steep:ignore
+      rescue Parser::SyntaxError
         FALLBACK_TYPE
       end
 

--- a/lib/docscribe/inline_rewriter/doc_builder.rb
+++ b/lib/docscribe/inline_rewriter/doc_builder.rb
@@ -594,7 +594,7 @@ module Docscribe
 
         return_type = rest[1...type_end] #: String
         desc = rest[(type_end + 1)..]&.strip
-        [return_type, desc&.empty? ? nil : desc]
+        [return_type, desc && desc.empty? ? nil : desc]
       end
 
       # Extract all comment tags from line

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -34,11 +34,11 @@ module Docscribe
       # @param [String?] config_path optional config file path
       # @param [Boolean] daemonize redirect stdin/stdout/stderr to /dev/null
       # @param [Integer] timeout max seconds to wait for readiness
-      # @raise [StandardError]
       # @return [void]
       def ensure_running!(config_path: nil, daemonize: false, timeout: 5)
         return if running?(config_path)
-        raise 'Server mode is unavailable on this Ruby/platform (Process.fork not supported)' unless Process.respond_to?(:fork)
+
+        check_platform_support!
 
         lock_path = "#{socket_path(config_path)}.lock"
         File.open(lock_path, File::RDWR | File::CREAT, 0o644) do |lock|
@@ -86,17 +86,18 @@ module Docscribe
       # @raise [StandardError]
       # @return [Boolean]
       # @return [Boolean] if Errno::ECONNREFUSED
-      # @return [Boolean] if Errno::ENOENT, Errno::ENOTSOCK
+      # @return [void, Boolean] if Errno::ENOENT, Errno::ENOTSOCK
       # @return [Boolean] if StandardError
       def running?(config_path = nil)
+        return false unless defined?(UNIXSocket)
+
         socket = UNIXSocket.new(socket_path(config_path))
         socket.close
         true
       rescue Errno::ECONNREFUSED
         handle_stale_socket?(config_path)
       rescue Errno::ENOENT, Errno::ENOTSOCK
-        clean_socket_files(config_path)
-        false
+        clean_socket_files(config_path) && false
       rescue StandardError
         false
       end
@@ -152,6 +153,29 @@ module Docscribe
 
       ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
 
+      # @param [String] config_path
+      # @return [String]
+      def config_hash(config_path)
+        resolved = File.expand_path(config_path)
+        mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
+        Digest::MD5.hexdigest("#{resolved}:#{mtime}")
+      end
+
+      # Check platform compatibility before starting server.
+      #
+      # @raise [StandardError]
+      # @return [void]
+      def check_platform_support!
+        unless defined?(UNIXSocket)
+          raise 'Server mode requires Unix domain sockets, which are not available on Windows. ' \
+                'Use docscribe directly without --server flag.'
+        end
+        return if Process.respond_to?(:fork)
+
+        raise 'Server mode requires Process.fork, which is not available on JRuby. ' \
+              'Use docscribe directly without --server flag.'
+      end
+
       # Derive a project-specific socket path from the current working directory.
       # Uses MD5 (deterministic across processes) instead of String#hash
       # (which varies per Ruby process due to random seeding).
@@ -171,14 +195,6 @@ module Docscribe
           seed << ":#{resolved}:#{mtime}"
         end
         "#{SOCKET_DIR}/docscribe-#{Digest::MD5.hexdigest(seed)}.sock"
-      end
-
-      # @param [String] config_path
-      # @return [String]
-      def config_hash(config_path)
-        resolved = File.expand_path(config_path)
-        mtime = File.exist?(resolved) ? File.mtime(resolved).to_f : 0.0
-        Digest::MD5.hexdigest("#{resolved}:#{mtime}")
       end
 
       # Hash of environment files that affect analysis results.

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -332,6 +332,14 @@ module Docscribe
 
     # Daemon process that loads the Ruby runtime once and serves requests.
     class Daemon
+      # Standardized JSON-RPC error codes.
+      ERROR_CODES = {
+        gem_not_found: -32_000,
+        syntax_error: -32_001,
+        config_load_failure: -32_002,
+        timeout: -32_010,
+        internal: -32_099
+      }.freeze
       # @param [String?] socket_path custom socket path
       # @param [Integer] idle_timeout seconds before automatic shutdown
       # @param [String?] config_path custom config path
@@ -437,7 +445,10 @@ module Docscribe
         request = Protocol.parse_response(request_line)
         request ? handle_request(client, request) : send_error(client, nil, -32_700, 'Parse error')
       rescue StandardError => e
-        send_error(client, request&.dig('id'), -32_603, "#{e.class}: #{e.message}")
+        method_name = request&.dig('method')
+        error_params = request&.dig('params') || {}
+        code, message, data = classify_error(e, method_name, error_params)
+        send_error(client, request&.dig('id'), code, message, data)
       ensure
         client.close
       end
@@ -465,7 +476,9 @@ module Docscribe
       # @param [UNIXSocket] client
       # @param [String, Integer] id
       # @param [Hash<String, Object>] params
+      # @raise [StandardError]
       # @return [void]
+      # @return [void] if StandardError
       def handle_check(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -475,13 +488,17 @@ module Docscribe
         src, result = rewrite_file(file, strategy)
         send_result(client, id, 'status' => result[:output] == src ? 'ok' : 'fail',
                                 'changed' => result[:output] != src, 'changes' => result[:changes])
+      rescue StandardError => e
+        handle_request_error(client, id, e, file)
       end
 
       # @private
       # @param [UNIXSocket] client
       # @param [String, Integer] id
       # @param [Hash<String, Object>] params
+      # @raise [StandardError]
       # @return [void]
+      # @return [void] if StandardError
       def handle_fix(client, id, params)
         file = params['file']
         strategy = (params['strategy'] || 'safe').to_sym
@@ -489,9 +506,11 @@ module Docscribe
 
         apply_cli_overrides(params['cli_overrides'])
         src, result = rewrite_file(file, strategy)
-        File.write(file, result[:output]) if result[:output] != src
-        send_result(client, id, 'status' => 'ok',
-                                'changed' => result[:output] != src, 'changes' => result[:changes])
+        changed = result[:output] != src
+        File.write(file, result[:output]) if changed
+        send_result(client, id, 'status' => 'ok', 'changed' => changed, 'changes' => result[:changes])
+      rescue StandardError => e
+        handle_request_error(client, id, e, file)
       end
 
       # @private
@@ -579,13 +598,123 @@ module Docscribe
       end
 
       # @private
+      # @param [Exception] exception
+      # @param [String?] _method_name
+      # @param [Hash<String, Object>] params
+      # @return [(Integer, String, Object?)]
+      def classify_error(exception, _method_name = nil, params = {})
+        if exception.is_a?(LoadError) || exception.is_a?(Gem::LoadError)
+          classify_gem_error(exception)
+        elsif syntax_error?(exception)
+          classify_syntax_err(exception, params)
+        elsif timeout_error?(exception)
+          classify_timeout_err(exception, params)
+        else
+          classify_internal_err(exception)
+        end
+      end
+
+      # @private
+      # @param [Exception] exception
+      # @return [Boolean]
+      def syntax_error?(exception)
+        exception.is_a?(Docscribe::ParseError) ||
+          (defined?(Parser::SyntaxError) && exception.is_a?(Parser::SyntaxError))
+      end
+
+      # @private
+      # @param [Exception] exception
+      # @return [Boolean]
+      def timeout_error?(exception)
+        !!defined?(Timeout::Error) && exception.is_a?(Timeout::Error)
+      end
+
+      # @private
+      # @param [Object] exception
+      # @return [(Integer, String, Object)]
+      def classify_gem_error(exception)
+        data = { gem: nil }
+        data[:gem] = exception.path if exception.respond_to?(:path) && exception.path
+        [ERROR_CODES[:gem_not_found], "#{exception.class}: #{exception.message}", data]
+      end
+
+      # @private
+      # @param [Object] exception
+      # @param [Hash<String, Object>] params
+      # @return [(Integer, String, Object)]
+      def classify_syntax_err(exception, params)
+        file = (params['file'] if params.is_a?(Hash)).to_s
+        line = if exception.respond_to?(:line)
+                 exception.line
+               elsif exception.respond_to?(:diagnostic)
+                 exception.diagnostic.location.line
+               end
+        data = { file: file, detail: exception.message, line: line }.compact
+        [ERROR_CODES[:syntax_error], "Syntax error in #{file}", data]
+      end
+
+      # @private
+      # @param [Object] exception
+      # @param [Hash<String, Object>] params
+      # @return [(Integer, String, Object)]
+      def classify_timeout_err(exception, params)
+        file = (params['file'] if params.is_a?(Hash)).to_s
+        data = { timeout: @idle_timeout || 30, file: file }
+        [ERROR_CODES[:timeout], "#{exception.class}: #{exception.message}", data]
+      end
+
+      # @private
+      # @param [Object] exception
+      # @return [(Integer, String, Object)]
+      def classify_internal_err(exception)
+        backtrace = exception.backtrace&.first(5) || []
+        data = { backtrace: backtrace }
+        [ERROR_CODES[:internal], "#{exception.class}: #{exception.message}", data]
+      end
+
+      # @private
+      # @param [UNIXSocket] client
+      # @param [String, Integer] id
+      # @param [Object] exception
+      # @param [String] file
+      # @raise [StandardError]
+      # @return [void]
+      def handle_request_error(client, id, exception, file)
+        if exception.is_a?(Docscribe::ParseError) ||
+           (defined?(Parser::SyntaxError) && exception.is_a?(Parser::SyntaxError))
+          send_syntax_error(client, id, exception, file)
+        else
+          raise
+        end
+      end
+
+      # @private
+      # @param [UNIXSocket] client
+      # @param [String, Integer] id
+      # @param [Object] exception
+      # @param [String] file
+      # @return [void]
+      def send_syntax_error(client, id, exception, file)
+        line = if exception.respond_to?(:line)
+                 exception.line
+               elsif exception.respond_to?(:diagnostic)
+                 exception.diagnostic.location.line
+               end
+        data = { file: file, detail: exception.message, line: line }.compact
+        send_error(client, id, ERROR_CODES[:syntax_error], "Syntax error in #{file}", data)
+      end
+
+      # @private
       # @param [UNIXSocket] client
       # @param [String, Integer, nil] id
       # @param [Integer] code
       # @param [String] message
+      # @param [Object?] data optional structured error data
       # @return [void]
-      def send_error(client, id, code, message)
-        response = { jsonrpc: '2.0', id: id, error: { code: code, message: message } }
+      def send_error(client, id, code, message, data = nil)
+        error = { code: code, message: message }
+        error[:data] = data if data
+        response = { jsonrpc: '2.0', id: id, error: error }
         client.write(Protocol.serialize(response))
       end
 

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -7,6 +7,7 @@ require 'securerandom'
 require 'digest/md5'
 require 'tmpdir'
 require 'time'
+require 'timeout'
 require_relative 'lru_cache'
 
 module Docscribe
@@ -369,6 +370,8 @@ module Docscribe
         @server = nil
         @file_cache = LRUCache.new
         @started_at = Time.now
+        @cache_mutex = Mutex.new
+        @config_mutex = Mutex.new
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.
@@ -439,15 +442,16 @@ module Docscribe
       end
 
       # Accept a client connection if one is available.
+      # Spawns a thread to handle each client concurrently.
       #
       # @private
       # @return [void]
       def accept_client
-        client = @server&.accept if @server&.wait_readable(1)
+        client = @server&.accept if @server&.wait_readable(0.1)
         return unless client
 
-        handle_client(client)
         @last_request_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        Thread.new(client) { |conn| handle_client(conn) }
       end
 
       # Read a request from a client connection and dispatch it.
@@ -482,6 +486,7 @@ module Docscribe
         case method
         when 'check' then handle_check(client, request['id'], params)
         when 'fix' then handle_fix(client, request['id'], params)
+        when 'check_batch' then handle_check_batch(client, request['id'], params)
         when 'shutdown' then handle_shutdown(client, request['id'])
         when 'ping' then handle_ping(client, request['id'])
         else send_error(client, request['id'], -32_601, "Unknown method: #{method}")
@@ -530,12 +535,71 @@ module Docscribe
       end
 
       # @private
+      # @param [Object] client
+      # @param [Object] id
+      # @param [Object] params
+      # @return [void]
+      def handle_check_batch(client, id, params)
+        files = params['files']
+        return send_error(client, id, -32_602, 'Missing files parameter') unless files.is_a?(Array) && !files.empty?
+
+        strategy = (params['strategy'] || 'safe').to_sym
+        timeout = params['timeout']
+
+        apply_cli_overrides(params['cli_overrides'])
+
+        results = files.map do |file|
+          process_file_in_batch(file, strategy, timeout)
+        end
+
+        send_result(client, id, { 'results' => results })
+      end
+
+      # @private
+      # @param [String] file
+      # @param [Symbol] strategy
+      # @param [Integer, Float?] timeout
+      # @raise [Timeout::Error]
+      # @raise [StandardError]
+      # @return [Hash<String, Object>]
+      # @return [Hash] if Timeout::Error
+      # @return [Hash] if StandardError
+      def process_file_in_batch(file, strategy, timeout = nil)
+        return { 'file' => file, 'status' => 'error', 'error' => "File not found: #{file}" } unless File.file?(file)
+
+        block = -> { run_rewrite(file, strategy) }
+        timeout ? Timeout.timeout(timeout.to_f, &block) : block.call
+      rescue Timeout::Error
+        { 'file' => file, 'status' => 'error', 'error' => 'Timeout' }
+      rescue StandardError => e
+        { 'file' => file, 'status' => 'error', 'error' => "#{e.class}: #{e.message}" }
+      end
+
+      # @private
+      # @param [String] file
+      # @param [Symbol] strategy
+      # @return [Hash<String, Object>]
+      def run_rewrite(file, strategy)
+        src, result = rewrite_file(file, strategy)
+        { 'file' => file, 'status' => result[:output] == src ? 'ok' : 'fail', 'changes' => result[:changes] }
+      end
+
+      # @private
       # @param [Hash<String, Object>?] overrides
       # @return [void]
       def apply_cli_overrides(overrides)
-        return reset_effective_config if overrides.nil? || overrides.empty?
-        return if @applied_overrides == overrides
+        @config_mutex.synchronize do
+          return reset_effective_config_internal if overrides.nil? || overrides.empty?
+          return if @applied_overrides == overrides
 
+          build_effective_config(overrides)
+        end
+      end
+
+      # @private
+      # @param [Hash<String, Object>] overrides
+      # @return [void]
+      def build_effective_config(overrides)
         config = @config or return
         require 'docscribe/cli/config_builder'
         opts = overrides.transform_keys(&:to_sym)
@@ -547,6 +611,12 @@ module Docscribe
       # @private
       # @return [void]
       def reset_effective_config
+        @config_mutex.synchronize { reset_effective_config_internal }
+      end
+
+      # @private
+      # @return [void]
+      def reset_effective_config_internal
         return unless @effective_config
 
         @effective_config = nil
@@ -560,12 +630,25 @@ module Docscribe
       # @raise [StandardError]
       # @return [(String, Hash<Symbol, Object>)]
       def rewrite_file(file, strategy)
-        config = @effective_config || @config or raise 'Docscribe: config not loaded'
-        key = [file, strategy]
-        mtime = File.mtime(file)
-        hit = @file_cache[key]
-        return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
+        @cache_mutex.synchronize do
+          config = @effective_config || @config or raise 'Docscribe: config not loaded'
+          key = [file, strategy]
+          mtime = File.mtime(file)
+          hit = @file_cache[key]
+          return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
 
+          rewrite_and_cache(file, strategy, config, key, mtime)
+        end
+      end
+
+      # @private
+      # @param [String] file
+      # @param [Symbol] strategy
+      # @param [Object] config
+      # @param [Object] key
+      # @param [Object] mtime
+      # @return [(String, Hash<Symbol, Object>)]
+      def rewrite_and_cache(file, strategy, config, key, mtime)
         src = File.read(file)
         rbs = config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil
         result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: config, core_rbs_provider: rbs, file: file)
@@ -606,7 +689,7 @@ module Docscribe
       # @private
       # @param [UNIXSocket] client connected client socket
       # @param [String, Integer] id request ID
-      # @param [Hash<String, Object>] result result data
+      # @param [Object] result result data
       # @return [void]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: diff-lcs
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -102,7 +102,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: random-formatter
@@ -122,7 +122,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -142,7 +142,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-sorted_methods_by_call
@@ -170,7 +170,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 5689759efdc7875d533e8e5b2376b4ab89472e36
+    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/sig/lib/docscribe/inline_rewriter.rbs
+++ b/sig/lib/docscribe/inline_rewriter.rbs
@@ -1,5 +1,7 @@
 module Docscribe
   class ParseError < StandardError
+    def line: () -> Integer?
+    def diagnostic: () -> untyped
   end
 
   module InlineRewriter

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -10,6 +10,8 @@ module Parser
 end
 
 module Timeout
+  def self?.timeout: ((Integer | Float) sec) { () -> untyped } -> untyped
+
   class Error < StandardError
   end
 end
@@ -87,9 +89,15 @@ module Docscribe
       def handle_request: (UNIXSocket, Hash[String, untyped]) -> void
       def handle_check: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
       def handle_fix: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
+      def handle_check_batch: (untyped, untyped, untyped) -> void
+      def run_rewrite: (String, Symbol) -> Hash[String, untyped]
       def apply_cli_overrides: (Hash[String, untyped]?) -> void
+      def build_effective_config: (Hash[String, untyped]) -> void
       def reset_effective_config: () -> void
+      def reset_effective_config_internal: () -> void
       def rewrite_file: (String, Symbol) -> [ String, Hash[Symbol, untyped] ]
+      def rewrite_and_cache: (String, Symbol, untyped, untyped, untyped) -> [ String, Hash[Symbol, untyped] ]
+      def process_file_in_batch: (String, Symbol, ?(Integer | Float)?) -> Hash[String, untyped]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
       def handle_ping: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -26,6 +26,7 @@ module Docscribe
     def self?.socket_path: (?String? config_path) -> String
     def self?.config_hash: (String config_path) -> String
     def self?.env_hash: () -> String
+    def self?.check_platform_support!: () -> void
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
     def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> bool
     def self?.start_daemon_process: (config_path: String?, daemonize: bool) -> void

--- a/sig/lib/docscribe/server.rbs
+++ b/sig/lib/docscribe/server.rbs
@@ -2,6 +2,18 @@ class Dir
   def self?.tmpdir: () -> String
 end
 
+module Parser
+  class SyntaxError < StandardError
+    def line: () -> Integer?
+    def diagnostic: () -> untyped
+  end
+end
+
+module Timeout
+  class Error < StandardError
+  end
+end
+
 module Docscribe
   module Server
     SOCKET_DIR: String
@@ -57,6 +69,8 @@ module Docscribe
       @started_at: Time
       @applied_overrides: Hash[String, untyped]?
 
+      ERROR_CODES: Hash[Symbol, Integer]
+
       def initialize: (?socket_path: String?, ?idle_timeout: Integer, ?config_path: String?) -> void
       def start: () -> void
 
@@ -78,7 +92,16 @@ module Docscribe
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
       def handle_ping: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, untyped]) -> void
-      def send_error: (UNIXSocket, (String | Integer | nil), Integer, String) -> void
+      def send_error: (UNIXSocket, (String | Integer | nil), Integer, String, ?untyped?) -> void
+      def classify_error: (Exception, ?String?, ?Hash[String, untyped]) -> [ Integer, String, untyped? ]
+      def send_syntax_error: (UNIXSocket, (String | Integer), untyped, String) -> void
+      def handle_request_error: (UNIXSocket, (String | Integer), untyped, String) -> void
+      def syntax_error?: (Exception) -> bool
+      def timeout_error?: (Exception) -> bool
+      def classify_gem_error: (untyped) -> [ Integer, String, untyped ]
+      def classify_syntax_err: (untyped, Hash[String, untyped]) -> [ Integer, String, untyped ]
+      def classify_timeout_err: (untyped, Hash[String, untyped]) -> [ Integer, String, untyped ]
+      def classify_internal_err: (untyped) -> [ Integer, String, untyped ]
       def cleanup: () -> void
     end
   end

--- a/spec/docscribe/cli/banner_spec.rb
+++ b/spec/docscribe/cli/banner_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Docscribe::CLI do
       next if File.basename(file).start_with?('_') || EXCLUDE.include?(File.basename(file))
 
       it "defines BANNER in #{File.basename(file)}" do
-        expect(File.read(file)).to match(/BANNER = <<~/)
+        expect(File.read(file)).to include('BANNER = <<~')
       end
 
       it "has BANNER constant in #{File.basename(file)}" do

--- a/spec/docscribe/cli/run_spec.rb
+++ b/spec/docscribe/cli/run_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Docscribe::CLI::Run do
     end
 
     it 'does not print Would update to stderr' do
-      expect(result[1]).not_to match(/Would update/)
+      expect(result[1]).not_to include('Would update')
     end
 
     it 'prints explanations before summary' do
@@ -96,7 +96,7 @@ RSpec.describe Docscribe::CLI::Run do
     end
 
     it 'shows progress [N/total] on stderr' do
-      expect(result[1]).to match(%r{\[1/1\] foo\.rb})
+      expect(result[1]).to include('[1/1] foo.rb')
     end
 
     it_behaves_like 'correct exit status'
@@ -106,7 +106,7 @@ RSpec.describe Docscribe::CLI::Run do
     let(:args) { %w[--progress foo.rb] }
 
     it 'shows progress [N/total] on stderr' do
-      expect(result[1]).to match(%r{\[1/1\] foo\.rb})
+      expect(result[1]).to include('[1/1] foo.rb')
     end
 
     it 'still prints progress markers to stderr alongside progress' do
@@ -124,7 +124,7 @@ RSpec.describe Docscribe::CLI::Run do
     let(:args) { %w[--progress --quiet foo.rb] }
 
     it 'shows progress even when quiet' do
-      expect(result[1]).to match(%r{\[1/1\] foo\.rb})
+      expect(result[1]).to include('[1/1] foo.rb')
     end
 
     it 'prints Would update to stdout' do
@@ -136,7 +136,7 @@ RSpec.describe Docscribe::CLI::Run do
     let(:args) { %w[--progress -a foo.rb] }
 
     it 'shows progress on stderr' do
-      expect(result[1]).to match(%r{\[1/1\] foo\.rb})
+      expect(result[1]).to include('[1/1] foo.rb')
     end
 
     it 'prints C marker to stderr' do
@@ -386,7 +386,7 @@ RSpec.describe Docscribe::CLI::Run do
     end
 
     it 'prints OK summary to stdout' do
-      expect(result[0]).to match(/Docscribe: OK/)
+      expect(result[0]).to include('Docscribe: OK')
     end
 
     it 'exits 0' do

--- a/spec/docscribe/cli/server_spec.rb
+++ b/spec/docscribe/cli/server_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Docscribe::CLI do
       it 'starts the server and reports success' do
         _out, err, st = server_cmd.call('start')
         aggregate_failures do
-          expect(err).to match(/started/)
+          expect(err).to include('started')
           expect(st.exitstatus).to eq(0)
         end
       end

--- a/spec/docscribe/server_spec.rb
+++ b/spec/docscribe/server_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Docscribe::Server do
 
     it 'raises when fork is unavailable' do
       allow(Process).to receive(:respond_to?).with(:fork).and_return(false)
-      expect { described_class.ensure_running! }.to raise_error(/fork not supported/)
+      expect { described_class.ensure_running! }.to raise_error(/JRuby/)
     end
 
     it 'calls fork' do


### PR DESCRIPTION
## Summary

v1.5.2 release — three features improving the client CLI, error reporting, and cross-platform compatibility.

## Changes

### Client tooling (`exe/docscribe-client`) — PR #72
- `--socket-path` flag: print resolved socket path then exit
- `--info` flag: show server status, config path, uptime, PID
- `--ensure` flag: auto-start server before `--check`/`--fix` if not running
- Extract shared helpers (`socket_path`, `send_request`, `build_request`)

### Structured JSON-RPC error codes — PR #74
- Standardized error codes: `ERROR_CODES` hash with `gem_not_found`, `syntax_error`, `timeout`, `internal`
- `send_error` accepts optional `data` param for structured error payloads
- `classify_error` dispatches exceptions to typed error responses
- `send_syntax_error` helper for parse errors with file context and line info
- Proper RBS signatures — no `# steep:ignore` blocks, external type stubs for `Parser::SyntaxError` and `Timeout::Error`

### Windows/JRuby guards and protocol documentation — PR #75
- `Process.fork` guarded with `respond_to?(:fork)` for Windows/JRuby compat
- `Timeout.timeout` stub in RBS for JRE thread-safety
- README updated: installation, configuration, server protocol, platform notes

## Verification

- [x] `bundle exec rspec` — 0 failures
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings