### PR TITLE
[1.6.0] Add config dump, coverage report, pre-commit hook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.5.2)
+    docscribe (1.6.0)
       parser (>= 3.3)
       prism (~> 1.8)
 
@@ -131,7 +131,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  docscribe (1.5.2)
+  docscribe (1.6.0)
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
   fileutils (1.8.0) sha256=8c6b1df54e2540bdb2f39258f08af78853aa70bad52b4d394bbc6424593c6e02

--- a/Gemfile_2_7.lock
+++ b/Gemfile_2_7.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    docscribe (1.5.2)
+    docscribe (1.6.0)
       parser (>= 3.3)
       prism (~> 1.8)
 

--- a/lib/docscribe/cli.rb
+++ b/lib/docscribe/cli.rb
@@ -18,13 +18,15 @@ module Docscribe
       end
 
       COMMANDS = {
-        'init' => :Init,
-        'generate' => :Generate,
-        'sigs' => :Sigs,
-        'rbs' => :RbsGen,
-        'update_types' => :UpdateTypes,
         'check_for_comments' => :CheckForComments,
-        'server' => :ServerCmd
+        'config' => :ConfigDump,
+        'coverage' => :Coverage,
+        'generate' => :Generate,
+        'init' => :Init,
+        'rbs' => :RbsGen,
+        'server' => :ServerCmd,
+        'sigs' => :Sigs,
+        'update_types' => :UpdateTypes
       }.freeze
 
       private

--- a/lib/docscribe/cli/config_dump.rb
+++ b/lib/docscribe/cli/config_dump.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'yaml'
+require 'docscribe/config'
+require 'docscribe/cli/config_builder'
+
+module Docscribe
+  module CLI
+    module ConfigDump
+      BANNER = <<~TEXT
+        Usage: docscribe config [options]
+
+        Print the fully resolved configuration as YAML.
+
+        Options:
+      TEXT
+
+      class << self
+        def run(argv)
+          opts = parse_options(argv)
+          return 0 if opts[:help]
+
+          conf = Docscribe::Config.load(opts[:config])
+          conf = Docscribe::CLI::ConfigBuilder.build(conf, parse_cli_overrides(argv))
+
+          puts conf.to_h.to_yaml
+          0
+        end
+
+        private
+
+        def parse_options(argv)
+          opts = { config: nil }
+          parser = OptionParser.new do |o|
+            o.banner = BANNER
+            o.on('--config PATH', 'Path to config file') { |v| opts[:config] = v }
+            o.on('-h', '--help', 'Show help') { opts[:help] = true; puts o }
+          end
+          parser.parse!(argv)
+          opts
+        end
+
+        def parse_cli_overrides(argv)
+          opts = Docscribe::CLI::Options.parse!(argv)
+          opts.slice(:rbs, :rbs_collection, :sorbet, :sig_dirs, :rbi_dirs, :include, :exclude)
+        end
+      end
+    end
+  end
+end

--- a/lib/docscribe/cli/config_dump.rb
+++ b/lib/docscribe/cli/config_dump.rb
@@ -17,6 +17,8 @@ module Docscribe
       TEXT
 
       class << self
+        # @param [Object] argv
+        # @return [Integer]
         def run(argv)
           opts = parse_options(argv)
           return 0 if opts[:help]
@@ -30,17 +32,26 @@ module Docscribe
 
         private
 
+        # @private
+        # @param [Object] argv
+        # @return [Hash]
         def parse_options(argv)
           opts = { config: nil }
           parser = OptionParser.new do |o|
             o.banner = BANNER
             o.on('--config PATH', 'Path to config file') { |v| opts[:config] = v }
-            o.on('-h', '--help', 'Show help') { opts[:help] = true; puts o }
+            o.on('-h', '--help', 'Show help') do
+              opts[:help] = true
+              puts o
+            end
           end
           parser.parse!(argv)
           opts
         end
 
+        # @private
+        # @param [Object] argv
+        # @return [Object]
         def parse_cli_overrides(argv)
           opts = Docscribe::CLI::Options.parse!(argv)
           opts.slice(:rbs, :rbs_collection, :sorbet, :sig_dirs, :rbi_dirs, :include, :exclude)

--- a/lib/docscribe/cli/config_dump.rb
+++ b/lib/docscribe/cli/config_dump.rb
@@ -7,6 +7,7 @@ require 'docscribe/cli/config_builder'
 
 module Docscribe
   module CLI
+    # Print the fully resolved configuration as YAML.
     module ConfigDump
       BANNER = <<~TEXT
         Usage: docscribe config [options]
@@ -17,7 +18,7 @@ module Docscribe
       TEXT
 
       class << self
-        # @param [Object] argv
+        # @param [Array<String>] argv
         # @return [Integer]
         def run(argv)
           opts = parse_options(argv)
@@ -33,11 +34,19 @@ module Docscribe
         private
 
         # @private
-        # @param [Object] argv
-        # @return [Hash]
+        # @param [Array<String>] argv
+        # @return [Hash<Symbol, Object>]
         def parse_options(argv)
           opts = { config: nil }
-          parser = OptionParser.new do |o|
+          build_parser(opts).parse!(argv)
+          opts
+        end
+
+        # @private
+        # @param [Hash<Symbol, Object>] opts
+        # @return [OptionParser]
+        def build_parser(opts)
+          OptionParser.new do |o|
             o.banner = BANNER
             o.on('--config PATH', 'Path to config file') { |v| opts[:config] = v }
             o.on('-h', '--help', 'Show help') do
@@ -45,13 +54,11 @@ module Docscribe
               puts o
             end
           end
-          parser.parse!(argv)
-          opts
         end
 
         # @private
-        # @param [Object] argv
-        # @return [Object]
+        # @param [Array<String>] argv
+        # @return [Hash<Symbol, Object>]
         def parse_cli_overrides(argv)
           opts = Docscribe::CLI::Options.parse!(argv)
           opts.slice(:rbs, :rbs_collection, :sorbet, :sig_dirs, :rbi_dirs, :include, :exclude)

--- a/lib/docscribe/cli/coverage.rb
+++ b/lib/docscribe/cli/coverage.rb
@@ -7,6 +7,7 @@ require 'docscribe/cli/options'
 
 module Docscribe
   module CLI
+    # Generate documentation coverage report for Ruby files.
     module Coverage
       BANNER = <<~TEXT
         Usage: docscribe coverage [options] [paths]
@@ -16,27 +17,56 @@ module Docscribe
         Options:
       TEXT
 
+      # @!attribute [rw] total_methods
+      #   @return [Integer]
+      #   @param [Integer] value
+      #
+      # @!attribute [rw] documented_methods
+      #   @return [Integer]
+      #   @param [Integer] value
+      #
+      # @!attribute [rw] total_params
+      #   @return [Integer]
+      #   @param [Integer] value
+      #
+      # @!attribute [rw] documented_params
+      #   @return [Integer]
+      #   @param [Integer] value
+      #
+      # @!attribute [rw] total_returns
+      #   @return [Integer]
+      #   @param [Integer] value
+      #
+      # @!attribute [rw] documented_returns
+      #   @return [Integer]
+      #   @param [Integer] value
       CoverageStats = Struct.new(
         :total_methods, :documented_methods,
         :total_params, :documented_params,
         :total_returns, :documented_returns,
         keyword_init: true
-      ) do
+      )
+
+      # Struct tracking documentation coverage metrics per file.
+      class CoverageStats
+        # @return [Integer, Float]
         def method_coverage
           total_methods.zero? ? 100.0 : (documented_methods.to_f / total_methods * 100).round(1)
         end
 
+        # @return [Integer, Float]
         def param_coverage
           total_params.zero? ? 100.0 : (documented_params.to_f / total_params * 100).round(1)
         end
 
+        # @return [Integer, Float]
         def return_coverage
           total_returns.zero? ? 100.0 : (documented_returns.to_f / total_returns * 100).round(1)
         end
       end
 
       class << self
-        # @param [Object] argv
+        # @param [Array<String>] argv
         # @return [Integer]
         def run(argv)
           opts = parse_options(argv)
@@ -54,11 +84,19 @@ module Docscribe
         private
 
         # @private
-        # @param [Object] argv
-        # @return [Hash]
+        # @param [Array<String>] argv
+        # @return [Hash<Symbol, Object>]
         def parse_options(argv)
           opts = { config: nil, format: 'text' }
-          parser = OptionParser.new do |o|
+          build_parser(opts).parse!(argv)
+          opts
+        end
+
+        # @private
+        # @param [Hash<Symbol, Object>] opts
+        # @return [OptionParser]
+        def build_parser(opts)
+          OptionParser.new do |o|
             o.banner = BANNER
             o.on('--config PATH', 'Path to config file') { |v| opts[:config] = v }
             o.on('--format FORMAT', 'Output format (text, json)') { |v| opts[:format] = v }
@@ -67,18 +105,24 @@ module Docscribe
               puts o
             end
           end
-          parser.parse!(argv)
-          opts
         end
 
         # @private
-        # @param [Object] argv
-        # @param [Object] conf
-        # @return [Array<Elem>]
+        # @param [Array<String>] argv
+        # @param [Docscribe::Config] conf
+        # @return [Array<String>]
         def expand_paths(argv, conf)
           require 'pathname'
           args = argv.empty? ? ['.'] : argv
-          files = []
+          files = expand_files(args)
+          files.uniq.sort.select { |p| conf.process_file?(p) }
+        end
+
+        # @private
+        # @param [Array<String>] args
+        # @return [Array<String>]
+        def expand_files(args)
+          files = [] #: Array[String]
           args.each do |path|
             if File.directory?(path)
               files.concat(Dir.glob(File.join(path, '**', '*.rb')))
@@ -86,84 +130,128 @@ module Docscribe
               files << path
             end
           end
-          files.uniq.sort.select { |p| conf.process_file?(p) }
+          files
         end
 
         # @private
-        # @param [Object] paths
-        # @param [Object] conf
-        # @raise [StandardError]
-        # @return [CoverageStats]
+        # @param [Array<String>] paths
+        # @param [Docscribe::Config] _conf
+        # @return [Docscribe::CLI::Coverage::CoverageStats]
         def analyze_coverage(paths, _conf)
           require 'docscribe/parsing'
           require 'parser/current'
 
-          stats = CoverageStats.new(
-            total_methods: 0, documented_methods: 0,
-            total_params: 0, documented_params: 0,
-            total_returns: 0, documented_returns: 0
-          )
-
-          paths.each do |path|
-            src = File.read(path)
-            buffer = Parser::Source::Buffer.new(path, source: src)
-            ast = Docscribe::Parsing.parse_buffer(buffer)
-            next unless ast
-
-            analyze_node(ast, stats, src)
-          rescue StandardError
-          end
-
+          stats = init_stats
+          paths.each { |path| analyze_file(path, stats) }
           stats
         end
 
         # @private
+        # @return [Docscribe::CLI::Coverage::CoverageStats]
+        def init_stats
+          CoverageStats.new(
+            total_methods: 0, documented_methods: 0,
+            total_params: 0, documented_params: 0,
+            total_returns: 0, documented_returns: 0
+          )
+        end
+
+        # @private
+        # @param [String] path
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @raise [StandardError]
+        # @return [void]
+        # @return [nil] if StandardError
+        def analyze_file(path, stats)
+          src = File.read(path)
+          buffer = Parser::Source::Buffer.new(path, source: src)
+          ast = Docscribe::Parsing.parse_buffer(buffer)
+          analyze_node(ast, stats, src) if ast
+        rescue StandardError => e
+          warn "Skipping #{path}: #{e.message}" if ENV.fetch('DOCSCRIBE_DEBUG', false)
+        end
+
+        # @private
         # @param [Object] node
-        # @param [Object] stats
-        # @param [Object] src
-        # @return [Object?]
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @param [String] src
+        # @return [void]
         def analyze_node(node, stats, src)
           return unless node.is_a?(Parser::AST::Node)
 
-          if %i[def defs].include?(node.type)
-            stats.total_methods += 1
-            line = node.loc.expression.line
-            doc_comment = extract_doc_comment(src, line)
-
-            if doc_comment
-              stats.documented_methods += 1
-
-              stats.documented_returns += 1 if doc_comment.match?(/@return\b/)
-              stats.total_returns += 1
-
-              param_matches = doc_comment.scan(/@param\b/)
-              args_node = node.children[2] || node.children[1]
-              if args_node.is_a?(Parser::AST::Node) && args_node.type == :args
-                param_count = args_node.children.count { |a| %i[arg optarg kwarg kwoptarg restarg].include?(a.type) }
-                stats.total_params += param_count
-                stats.documented_params += [param_matches.size, param_count].min
-              end
-            else
-              stats.total_returns += 1
-              args_node = node.children[2] || node.children[1]
-              if args_node.is_a?(Parser::AST::Node) && args_node.type == :args
-                stats.total_params += args_node.children.count { |a| %i[arg optarg kwarg kwoptarg restarg].include?(a.type) }
-              end
-            end
-          end
+          analyze_method_node(node, stats, src) if %i[def defs].include?(node.type)
 
           node.children.each { |child| analyze_node(child, stats, src) if child.is_a?(Parser::AST::Node) }
         end
 
         # @private
-        # @param [Object] src
-        # @param [Object] method_line
-        # @return [String]
+        # @param [Object] node
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @param [String] src
+        # @return [void]
+        def analyze_method_node(node, stats, src)
+          stats.total_methods += 1
+          doc_comment = extract_doc_comment(src, node.loc.expression.line)
+
+          if doc_comment
+            analyze_documented_method(node, stats, doc_comment)
+          else
+            stats.total_returns += 1
+            count_method_params(node, stats)
+          end
+        end
+
+        # @private
+        # @param [Object] node
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @param [String] doc_comment
+        # @return [void]
+        def analyze_documented_method(node, stats, doc_comment)
+          stats.documented_methods += 1
+          stats.documented_returns += 1 if doc_comment.match?(/@return\b/)
+          stats.total_returns += 1
+
+          param_matches = doc_comment.scan(/@param\b/)
+          param_count = count_params(node)
+          stats.total_params += param_count
+          stats.documented_params += [param_matches.size, param_count].min
+        end
+
+        # @private
+        # @param [Object] node
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @return [void]
+        def count_method_params(node, stats)
+          stats.total_params += count_params(node)
+        end
+
+        # @private
+        # @param [Object] node
+        # @return [Integer]
+        def count_params(node)
+          args_node = node.children[2] || node.children[1]
+          return 0 unless args_node.is_a?(Parser::AST::Node) && args_node.type == :args
+
+          args_node.children.count { |a| %i[arg optarg kwarg kwoptarg restarg].include?(a.type) }
+        end
+
+        # @private
+        # @param [String] src
+        # @param [Integer] method_line
+        # @return [String?]
         def extract_doc_comment(src, method_line)
           lines = src.lines
-          comment_lines = []
-          idx = method_line - 2
+          comment_lines = collect_comment_lines(lines, method_line)
+          comment_lines.empty? ? nil : comment_lines.join
+        end
 
+        # @private
+        # @param [Array<String>] lines
+        # @param [Integer] method_line
+        # @return [Array<String>]
+        def collect_comment_lines(lines, method_line)
+          comment_lines = [] #: Array[String]
+          idx = method_line - 2
           while idx >= 0
             line = lines[idx]
             break unless line =~ /^\s*#/
@@ -171,33 +259,53 @@ module Docscribe
             comment_lines.unshift(line)
             idx -= 1
           end
-
-          return nil if comment_lines.empty?
-
-          comment_lines.join
+          comment_lines
         end
 
         # @private
-        # @param [Object] stats
-        # @param [Object] opts
-        # @return [Object]
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @param [Hash<Symbol, Object>] opts
+        # @return [void]
         def print_report(stats, opts)
           case opts[:format]
           when 'json'
-            require 'json'
-            puts JSON.pretty_generate(
-              methods: { total: stats.total_methods, documented: stats.documented_methods, coverage: stats.method_coverage },
-              params: { total: stats.total_params, documented: stats.documented_params, coverage: stats.param_coverage },
-              returns: { total: stats.total_returns, documented: stats.documented_returns, coverage: stats.return_coverage }
-            )
+            print_json_report(stats)
           else
-            puts 'Documentation Coverage Report'
-            puts '============================='
-            puts
-            puts "Methods: #{stats.documented_methods}/#{stats.total_methods} (#{stats.method_coverage}%)"
-            puts "Params:  #{stats.documented_params}/#{stats.total_params} (#{stats.param_coverage}%)"
-            puts "Returns: #{stats.documented_returns}/#{stats.total_returns} (#{stats.return_coverage}%)"
+            print_text_report(stats)
           end
+        end
+
+        # @private
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @return [void]
+        def print_json_report(stats)
+          require 'json'
+          puts JSON.pretty_generate(
+            methods: report_entry(stats.total_methods, stats.documented_methods, stats.method_coverage),
+            params: report_entry(stats.total_params, stats.documented_params, stats.param_coverage),
+            returns: report_entry(stats.total_returns, stats.documented_returns, stats.return_coverage)
+          )
+        end
+
+        # @private
+        # @param [Integer] total
+        # @param [Integer] documented
+        # @param [Integer, Float] coverage
+        # @return [Hash<Symbol, Integer, Float>]
+        def report_entry(total, documented, coverage)
+          { total: total, documented: documented, coverage: coverage }
+        end
+
+        # @private
+        # @param [Docscribe::CLI::Coverage::CoverageStats] stats
+        # @return [void]
+        def print_text_report(stats)
+          puts 'Documentation Coverage Report'
+          puts '============================='
+          puts
+          puts "Methods: #{stats.documented_methods}/#{stats.total_methods} (#{stats.method_coverage}%)"
+          puts "Params:  #{stats.documented_params}/#{stats.total_params} (#{stats.param_coverage}%)"
+          puts "Returns: #{stats.documented_returns}/#{stats.total_returns} (#{stats.return_coverage}%)"
         end
       end
     end

--- a/lib/docscribe/cli/coverage.rb
+++ b/lib/docscribe/cli/coverage.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'docscribe/config'
+require 'docscribe/cli/config_builder'
+require 'docscribe/cli/options'
+
+module Docscribe
+  module CLI
+    module Coverage
+      BANNER = <<~TEXT
+        Usage: docscribe coverage [options] [paths]
+
+        Generate documentation coverage report.
+
+        Options:
+      TEXT
+
+      CoverageStats = Struct.new(
+        :total_methods, :documented_methods,
+        :total_params, :documented_params,
+        :total_returns, :documented_returns,
+        keyword_init: true
+      ) do
+        def method_coverage
+          total_methods.zero? ? 100.0 : (documented_methods.to_f / total_methods * 100).round(1)
+        end
+
+        def param_coverage
+          total_params.zero? ? 100.0 : (documented_params.to_f / total_params * 100).round(1)
+        end
+
+        def return_coverage
+          total_returns.zero? ? 100.0 : (documented_returns.to_f / total_returns * 100).round(1)
+        end
+      end
+
+      class << self
+        def run(argv)
+          opts = parse_options(argv)
+          return 0 if opts[:help]
+
+          conf = Docscribe::Config.load(opts[:config])
+          paths = expand_paths(argv, conf)
+
+          stats = analyze_coverage(paths, conf)
+
+          print_report(stats, opts)
+          0
+        end
+
+        private
+
+        def parse_options(argv)
+          opts = { config: nil, format: 'text' }
+          parser = OptionParser.new do |o|
+            o.banner = BANNER
+            o.on('--config PATH', 'Path to config file') { |v| opts[:config] = v }
+            o.on('--format FORMAT', 'Output format (text, json)') { |v| opts[:format] = v }
+            o.on('-h', '--help', 'Show help') { opts[:help] = true; puts o }
+          end
+          parser.parse!(argv)
+          opts
+        end
+
+        def expand_paths(argv, conf)
+          require 'pathname'
+          args = argv.empty? ? ['.'] : argv
+          files = []
+          args.each do |path|
+            if File.directory?(path)
+              files.concat(Dir.glob(File.join(path, '**', '*.rb')))
+            elsif File.file?(path)
+              files << path
+            end
+          end
+          files.uniq.sort.select { |p| conf.process_file?(p) }
+        end
+
+        def analyze_coverage(paths, conf)
+          require 'docscribe/parsing'
+          require 'parser/current'
+
+          stats = CoverageStats.new(
+            total_methods: 0, documented_methods: 0,
+            total_params: 0, documented_params: 0,
+            total_returns: 0, documented_returns: 0
+          )
+
+          paths.each do |path|
+            src = File.read(path)
+            buffer = Parser::Source::Buffer.new(path, source: src)
+            ast = Docscribe::Parsing.parse_buffer(buffer)
+            next unless ast
+
+            analyze_node(ast, stats, src)
+          rescue StandardError
+          end
+
+          stats
+        end
+
+        def analyze_node(node, stats, src)
+          return unless node.is_a?(Parser::AST::Node)
+
+          if %i[def defs].include?(node.type)
+            stats.total_methods += 1
+            line = node.loc.expression.line
+            doc_comment = extract_doc_comment(src, line)
+
+            if doc_comment
+              stats.documented_methods += 1
+
+              if doc_comment.match?(/@return\b/)
+                stats.documented_returns += 1
+              end
+              stats.total_returns += 1
+
+              param_matches = doc_comment.scan(/@param\b/)
+              args_node = node.children[2] || node.children[1]
+              if args_node.is_a?(Parser::AST::Node) && args_node.type == :args
+                param_count = args_node.children.count { |a| %i[arg optarg kwarg kwoptarg restarg].include?(a.type) }
+                stats.total_params += param_count
+                stats.documented_params += [param_matches.size, param_count].min
+              end
+            else
+              stats.total_returns += 1
+              args_node = node.children[2] || node.children[1]
+              if args_node.is_a?(Parser::AST::Node) && args_node.type == :args
+                stats.total_params += args_node.children.count { |a| %i[arg optarg kwarg kwoptarg restarg].include?(a.type) }
+              end
+            end
+          end
+
+          node.children.each { |child| analyze_node(child, stats, src) if child.is_a?(Parser::AST::Node) }
+        end
+
+        def extract_doc_comment(src, method_line)
+          lines = src.lines
+          comment_lines = []
+          idx = method_line - 2
+
+          while idx >= 0
+            line = lines[idx]
+            break unless line =~ /^\s*#/
+            comment_lines.unshift(line)
+            idx -= 1
+          end
+
+          return nil if comment_lines.empty?
+          comment_lines.join
+        end
+
+        def print_report(stats, opts)
+          case opts[:format]
+          when 'json'
+            require 'json'
+            puts JSON.pretty_generate(
+              methods: { total: stats.total_methods, documented: stats.documented_methods, coverage: stats.method_coverage },
+              params: { total: stats.total_params, documented: stats.documented_params, coverage: stats.param_coverage },
+              returns: { total: stats.total_returns, documented: stats.documented_returns, coverage: stats.return_coverage }
+            )
+          else
+            puts "Documentation Coverage Report"
+            puts "============================="
+            puts
+            puts "Methods: #{stats.documented_methods}/#{stats.total_methods} (#{stats.method_coverage}%)"
+            puts "Params:  #{stats.documented_params}/#{stats.total_params} (#{stats.param_coverage}%)"
+            puts "Returns: #{stats.documented_returns}/#{stats.total_returns} (#{stats.return_coverage}%)"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/docscribe/cli/coverage.rb
+++ b/lib/docscribe/cli/coverage.rb
@@ -36,6 +36,8 @@ module Docscribe
       end
 
       class << self
+        # @param [Object] argv
+        # @return [Integer]
         def run(argv)
           opts = parse_options(argv)
           return 0 if opts[:help]
@@ -51,18 +53,28 @@ module Docscribe
 
         private
 
+        # @private
+        # @param [Object] argv
+        # @return [Hash]
         def parse_options(argv)
           opts = { config: nil, format: 'text' }
           parser = OptionParser.new do |o|
             o.banner = BANNER
             o.on('--config PATH', 'Path to config file') { |v| opts[:config] = v }
             o.on('--format FORMAT', 'Output format (text, json)') { |v| opts[:format] = v }
-            o.on('-h', '--help', 'Show help') { opts[:help] = true; puts o }
+            o.on('-h', '--help', 'Show help') do
+              opts[:help] = true
+              puts o
+            end
           end
           parser.parse!(argv)
           opts
         end
 
+        # @private
+        # @param [Object] argv
+        # @param [Object] conf
+        # @return [Array<Elem>]
         def expand_paths(argv, conf)
           require 'pathname'
           args = argv.empty? ? ['.'] : argv
@@ -77,7 +89,12 @@ module Docscribe
           files.uniq.sort.select { |p| conf.process_file?(p) }
         end
 
-        def analyze_coverage(paths, conf)
+        # @private
+        # @param [Object] paths
+        # @param [Object] conf
+        # @raise [StandardError]
+        # @return [CoverageStats]
+        def analyze_coverage(paths, _conf)
           require 'docscribe/parsing'
           require 'parser/current'
 
@@ -100,6 +117,11 @@ module Docscribe
           stats
         end
 
+        # @private
+        # @param [Object] node
+        # @param [Object] stats
+        # @param [Object] src
+        # @return [Object?]
         def analyze_node(node, stats, src)
           return unless node.is_a?(Parser::AST::Node)
 
@@ -111,9 +133,7 @@ module Docscribe
             if doc_comment
               stats.documented_methods += 1
 
-              if doc_comment.match?(/@return\b/)
-                stats.documented_returns += 1
-              end
+              stats.documented_returns += 1 if doc_comment.match?(/@return\b/)
               stats.total_returns += 1
 
               param_matches = doc_comment.scan(/@param\b/)
@@ -135,6 +155,10 @@ module Docscribe
           node.children.each { |child| analyze_node(child, stats, src) if child.is_a?(Parser::AST::Node) }
         end
 
+        # @private
+        # @param [Object] src
+        # @param [Object] method_line
+        # @return [String]
         def extract_doc_comment(src, method_line)
           lines = src.lines
           comment_lines = []
@@ -143,14 +167,20 @@ module Docscribe
           while idx >= 0
             line = lines[idx]
             break unless line =~ /^\s*#/
+
             comment_lines.unshift(line)
             idx -= 1
           end
 
           return nil if comment_lines.empty?
+
           comment_lines.join
         end
 
+        # @private
+        # @param [Object] stats
+        # @param [Object] opts
+        # @return [Object]
         def print_report(stats, opts)
           case opts[:format]
           when 'json'
@@ -161,8 +191,8 @@ module Docscribe
               returns: { total: stats.total_returns, documented: stats.documented_returns, coverage: stats.return_coverage }
             )
           else
-            puts "Documentation Coverage Report"
-            puts "============================="
+            puts 'Documentation Coverage Report'
+            puts '============================='
             puts
             puts "Methods: #{stats.documented_methods}/#{stats.total_methods} (#{stats.method_coverage}%)"
             puts "Params:  #{stats.documented_params}/#{stats.total_params} (#{stats.param_coverage}%)"

--- a/lib/docscribe/cli/init.rb
+++ b/lib/docscribe/cli/init.rb
@@ -87,9 +87,7 @@ module Docscribe
         # @param [String] yaml config template content
         # @return [Integer] exit code
         def write_init_config(opts, yaml)
-          if opts[:pre_commit]
-            return install_pre_commit_hook(opts)
-          end
+          return install_pre_commit_hook(opts) if opts[:pre_commit]
 
           path = opts[:config]
           if File.exist?(path) && !opts[:force]
@@ -101,12 +99,16 @@ module Docscribe
           puts "Created: #{path}"
           0
         end
+
+        # @private
+        # @param [Object] opts
+        # @return [Integer]
         def install_pre_commit_hook(opts)
           hook_dir = File.join('.git', 'hooks')
           hook_path = File.join(hook_dir, 'pre-commit')
 
           unless Dir.exist?(hook_dir)
-            warn "No .git/hooks directory found. Are you in a git repository?"
+            warn 'No .git/hooks directory found. Are you in a git repository?'
             return 1
           end
 
@@ -115,7 +117,7 @@ module Docscribe
             return 1
           end
 
-          hook_content = <<~'HOOK'
+          hook_content = <<~HOOK
             #!/bin/sh
             # Docscribe pre-commit hook
             # Runs docscribe check on staged Ruby files

--- a/lib/docscribe/cli/init.rb
+++ b/lib/docscribe/cli/init.rb
@@ -69,15 +69,25 @@ module Docscribe
         def build_init_parser(opts)
           OptionParser.new do |o|
             o.banner = BANNER
-            o.on('--config PATH', 'Where to write the config (default: docscribe.yml)') { |v| opts[:config] = v }
-            o.on('-f', '--force', 'Overwrite if the file already exists') { opts[:force] = true }
-            o.on('--stdout', 'Print config template to STDOUT instead of writing a file') { opts[:stdout] = true }
-            o.on('--pre-commit', 'Install pre-commit hook for docscribe check') { opts[:pre_commit] = true }
+            add_init_options(o, opts)
             o.on('-h', '--help', 'Show this help') do
               opts[:help] = true
               puts o
             end
           end
+        end
+
+        # Add init-specific CLI options to the parser.
+        #
+        # @private
+        # @param [OptionParser] parser
+        # @param [Hash<Symbol, Object>] opts options hash
+        # @return [void]
+        def add_init_options(parser, opts)
+          parser.on('--config PATH', 'Where to write the config (default: docscribe.yml)') { |v| opts[:config] = v }
+          parser.on('-f', '--force', 'Overwrite if the file already exists') { opts[:force] = true }
+          parser.on('--stdout', 'Print config template to STDOUT instead of writing a file') { opts[:stdout] = true }
+          parser.on('--pre-commit', 'Install pre-commit hook for docscribe check') { opts[:pre_commit] = true }
         end
 
         # Write the config template to a file.
@@ -101,23 +111,47 @@ module Docscribe
         end
 
         # @private
-        # @param [Object] opts
+        # @param [Hash<Symbol, Object>] opts
         # @return [Integer]
         def install_pre_commit_hook(opts)
           hook_dir = File.join('.git', 'hooks')
           hook_path = File.join(hook_dir, 'pre-commit')
 
+          return 1 unless hook_preconditions_met?(hook_dir, hook_path, opts)
+
+          File.write(hook_path, pre_commit_hook_script)
+          File.chmod(0o755, hook_path)
+          puts "Installed pre-commit hook: #{hook_path}"
+          0
+        end
+
+        # Check pre-commit hook installation preconditions.
+        #
+        # @private
+        # @param [String] hook_dir
+        # @param [String] hook_path
+        # @param [Hash<Symbol, Object>] opts
+        # @return [Boolean]
+        def hook_preconditions_met?(hook_dir, hook_path, opts)
           unless Dir.exist?(hook_dir)
             warn 'No .git/hooks directory found. Are you in a git repository?'
-            return 1
+            return false
           end
 
           if File.exist?(hook_path) && !opts[:force]
             warn "Pre-commit hook already exists: #{hook_path} (use --force to overwrite)"
-            return 1
+            return false
           end
 
-          hook_content = <<~HOOK
+          true
+        end
+
+        # Generate the pre-commit hook shell script content.
+        #
+        # @private
+        # @return [String]
+        def pre_commit_hook_script
+          <<~HOOK
             #!/bin/sh
             # Docscribe pre-commit hook
             # Runs docscribe check on staged Ruby files
@@ -138,11 +172,6 @@ module Docscribe
 
             exit 0
           HOOK
-
-          File.write(hook_path, hook_content)
-          File.chmod(0o755, hook_path)
-          puts "Installed pre-commit hook: #{hook_path}"
-          0
         end
       end
     end

--- a/lib/docscribe/cli/init.rb
+++ b/lib/docscribe/cli/init.rb
@@ -58,7 +58,7 @@ module Docscribe
         # @private
         # @return [Hash<Symbol, String, Boolean>]
         def default_init_options
-          { config: 'docscribe.yml', force: false, stdout: false, help: false }
+          { config: 'docscribe.yml', force: false, stdout: false, help: false, pre_commit: false }
         end
 
         # Build and return an OptionParser for the init command.
@@ -72,6 +72,7 @@ module Docscribe
             o.on('--config PATH', 'Where to write the config (default: docscribe.yml)') { |v| opts[:config] = v }
             o.on('-f', '--force', 'Overwrite if the file already exists') { opts[:force] = true }
             o.on('--stdout', 'Print config template to STDOUT instead of writing a file') { opts[:stdout] = true }
+            o.on('--pre-commit', 'Install pre-commit hook for docscribe check') { opts[:pre_commit] = true }
             o.on('-h', '--help', 'Show this help') do
               opts[:help] = true
               puts o
@@ -86,6 +87,10 @@ module Docscribe
         # @param [String] yaml config template content
         # @return [Integer] exit code
         def write_init_config(opts, yaml)
+          if opts[:pre_commit]
+            return install_pre_commit_hook(opts)
+          end
+
           path = opts[:config]
           if File.exist?(path) && !opts[:force]
             warn "Config already exists: #{path} (use --force to overwrite)"
@@ -94,6 +99,47 @@ module Docscribe
 
           File.write(path, yaml)
           puts "Created: #{path}"
+          0
+        end
+        def install_pre_commit_hook(opts)
+          hook_dir = File.join('.git', 'hooks')
+          hook_path = File.join(hook_dir, 'pre-commit')
+
+          unless Dir.exist?(hook_dir)
+            warn "No .git/hooks directory found. Are you in a git repository?"
+            return 1
+          end
+
+          if File.exist?(hook_path) && !opts[:force]
+            warn "Pre-commit hook already exists: #{hook_path} (use --force to overwrite)"
+            return 1
+          end
+
+          hook_content = <<~'HOOK'
+            #!/bin/sh
+            # Docscribe pre-commit hook
+            # Runs docscribe check on staged Ruby files
+
+            STAGED_RUBY_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.rb')
+            if [ -z "$STAGED_RUBY_FILES" ]; then
+              exit 0
+            fi
+
+            echo "Checking documentation with docscribe..."
+            bundle exec docscribe check $STAGED_RUBY_FILES
+            RESULT=$?
+
+            if [ $RESULT -ne 0 ]; then
+              echo "Documentation check failed. Please add documentation before committing."
+              exit 1
+            fi
+
+            exit 0
+          HOOK
+
+          File.write(hook_path, hook_content)
+          File.chmod(0o755, hook_path)
+          puts "Installed pre-commit hook: #{hook_path}"
           0
         end
       end

--- a/lib/docscribe/config.rb
+++ b/lib/docscribe/config.rb
@@ -26,6 +26,15 @@ module Docscribe
       @raw = deep_merge(DEFAULT, raw)
       @config_path = config_path
     end
+
+    def to_h
+      hash = {}
+      instance_variables.each do |var|
+        key = var.to_s.sub('@', '')
+        hash[key] = instance_variable_get(var)
+      end
+      hash
+    end
   end
 end
 

--- a/lib/docscribe/config.rb
+++ b/lib/docscribe/config.rb
@@ -27,6 +27,7 @@ module Docscribe
       @config_path = config_path
     end
 
+    # @return [Hash]
     def to_h
       hash = {}
       instance_variables.each do |var|

--- a/lib/docscribe/config.rb
+++ b/lib/docscribe/config.rb
@@ -27,9 +27,9 @@ module Docscribe
       @config_path = config_path
     end
 
-    # @return [Hash]
+    # @return [Object]
     def to_h
-      hash = {}
+      hash = {} #: Hash[String, Object]
       instance_variables.each do |var|
         key = var.to_s.sub('@', '')
         hash[key] = instance_variable_get(var)

--- a/lib/docscribe/server.rb
+++ b/lib/docscribe/server.rb
@@ -689,7 +689,7 @@ module Docscribe
       # @private
       # @param [UNIXSocket] client connected client socket
       # @param [String, Integer] id request ID
-      # @param [Object] result result data
+      # @param [Hash<String, Object>] result result data
       # @return [void]
       def send_result(client, id, result)
         response = { jsonrpc: '2.0', id: id, result: result }

--- a/lib/docscribe/version.rb
+++ b/lib/docscribe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Docscribe
-  VERSION = '1.5.2'
+  VERSION = '1.6.0'
 end

--- a/sig/lib/docscribe/cli/config_dump.rbs
+++ b/sig/lib/docscribe/cli/config_dump.rbs
@@ -1,0 +1,15 @@
+module Docscribe
+  module CLI
+    module ConfigDump
+      BANNER: String
+
+      def self.run: (Array[String] argv) -> 0
+
+      private
+
+      def self.parse_options: (Array[String] argv) -> Hash[Symbol, untyped]
+      def self.build_parser: (Hash[Symbol, untyped] opts) -> OptionParser
+      def self.parse_cli_overrides: (Array[String] argv) -> Hash[Symbol, untyped]
+    end
+  end
+end

--- a/sig/lib/docscribe/cli/coverage.rbs
+++ b/sig/lib/docscribe/cli/coverage.rbs
@@ -1,0 +1,45 @@
+module Docscribe
+  module CLI
+    module Coverage
+      BANNER: String
+
+      class CoverageStats
+        attr_accessor total_methods: Integer
+        attr_accessor documented_methods: Integer
+        attr_accessor total_params: Integer
+        attr_accessor documented_params: Integer
+        attr_accessor total_returns: Integer
+        attr_accessor documented_returns: Integer
+
+        def initialize: (?total_methods: Integer, ?documented_methods: Integer, ?total_params: Integer, ?documented_params: Integer, ?total_returns: Integer, ?documented_returns: Integer) -> void
+
+        def method_coverage: () -> (Integer | Float)
+        def param_coverage: () -> (Integer | Float)
+        def return_coverage: () -> (Integer | Float)
+      end
+
+      def self.run: (Array[String] argv) -> 0
+
+      private
+
+      def self.parse_options: (Array[String] argv) -> Hash[Symbol, untyped]
+      def self.build_parser: (Hash[Symbol, untyped] opts) -> OptionParser
+      def self.expand_paths: (Array[String] argv, Config conf) -> Array[String]
+      def self.expand_files: (Array[String] args) -> Array[String]
+      def self.analyze_coverage: (Array[String] paths, Config _conf) -> CoverageStats
+      def self.init_stats: () -> CoverageStats
+      def self.analyze_file: (String path, CoverageStats stats) -> void
+      def self.analyze_node: (untyped node, CoverageStats stats, String src) -> void
+      def self.analyze_method_node: (untyped node, CoverageStats stats, String src) -> void
+      def self.analyze_documented_method: (untyped node, CoverageStats stats, String doc_comment) -> void
+      def self.count_method_params: (untyped node, CoverageStats stats) -> void
+      def self.count_params: (untyped node) -> Integer
+      def self.extract_doc_comment: (String src, Integer method_line) -> String?
+      def self.collect_comment_lines: (Array[String] lines, Integer method_line) -> Array[String]
+      def self.print_report: (CoverageStats stats, Hash[Symbol, untyped] opts) -> void
+      def self.print_json_report: (CoverageStats stats) -> void
+      def self.report_entry: (Integer total, Integer documented, (Integer | Float) coverage) -> Hash[Symbol, Integer | Float]
+      def self.print_text_report: (CoverageStats stats) -> void
+    end
+  end
+end

--- a/sig/lib/docscribe/cli/init.rbs
+++ b/sig/lib/docscribe/cli/init.rbs
@@ -9,11 +9,15 @@ module Docscribe
 
       def self.parse_init_options: (Array[String] argv) -> Hash[Symbol, untyped]
 
-      def self.default_init_options: () -> { config: "docscribe.yml", force: false, stdout: false, help: false }
+      def self.default_init_options: () -> { config: "docscribe.yml", force: false, stdout: false, help: false, pre_commit: bool }
 
       def self.build_init_parser: (Hash[Symbol, untyped] opts) -> OptionParser
 
       def self.write_init_config: (Hash[Symbol, untyped] opts, String yaml) -> (1 | 0)
+      def self.add_init_options: (OptionParser parser, Hash[Symbol, untyped] opts) -> void
+      def self.install_pre_commit_hook: (Hash[Symbol, untyped] opts) -> (0 | 1)
+      def self.hook_preconditions_met?: (String hook_dir, String hook_path, Hash[Symbol, untyped] opts) -> bool
+      def self.pre_commit_hook_script: () -> String
     end
   end
 end

--- a/sig/lib/docscribe/config.rbs
+++ b/sig/lib/docscribe/config.rbs
@@ -7,5 +7,6 @@ module Docscribe
     attr_reader config_path: String?
 
     def initialize: (?config_path: String?, **Hash[String, Object] raw) -> void
+    def to_h: () -> untyped
   end
 end


### PR DESCRIPTION
## Summary

Add three new CLI subcommands and `--pre-commit` flag to `docscribe init`.

## Changes

- **`docscribe config`** — print full resolved configuration as YAML. Reads config file, applies CLI overrides, outputs to stdout.
- **`docscribe coverage`** — generate documentation coverage report for Ruby files. Scans methods/params/returns, prints text or JSON report with percentages.
- **`docscribe init --pre-commit`** — install a git pre-commit hook that runs `docscribe check` on staged `.rb` files.
- **`Config#to_h`** — expose config state as a hash for serialization.
- **`version.rb`** — bump to 1.6.0.
- **RBS signatures** — add/update sigs for new modules (`ConfigDump`, `Coverage`) and updated `Init`.
- **Lockfiles** — bump parsed dependency versions.

## Verification

- `bundle exec rspec` — all tests pass
- `bundle exec rubocop` — 0 offenses
- `bundle exec steep check` — no type errors