### PR TITLE
[1.6.2] Invalidate daemon cache on sig change

### DIFF
--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -28,16 +28,25 @@ def socket_path(config_path = nil)
 end
 
 def env_hash
-  parts = ENV_FILES.map do |file|
-    path = File.join(Dir.pwd, file)
-    File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
-  end
-  sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
-  sig_files.each do |sig_path|
-    parts << File.mtime(sig_path).to_f.to_s
-  end
-  parts << sig_files.size.to_s
+  parts = ENV_FILES.map { |file| env_file_mtime(file) }
+  parts.concat(sig_env_parts)
   Digest::MD5.hexdigest(parts.join(':'))
+end
+
+def env_file_mtime(file)
+  path = File.join(Dir.pwd, file)
+  File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
+end
+
+def sig_env_parts
+  files = sig_files
+  mtimes = files.map { |p| File.mtime(p).to_f.to_s }
+  mtimes << files.size.to_s
+  mtimes
+end
+
+def sig_files
+  Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
 end
 
 def config_hash(config_path)

--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -13,7 +13,8 @@ SOCKET_DIR = begin
   sock_overhead = "/docscribe-#{'a' * 32}.sock".bytesize
   tmp.bytesize <= 104 - sock_overhead ? tmp : '/tmp'
 end
-ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
+ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml docscribe.yml].freeze
+SIG_RBS_GLOB = 'sig/**/*.rbs'
 
 def socket_path(config_path = nil)
   seed = +Dir.pwd
@@ -31,6 +32,11 @@ def env_hash
     path = File.join(Dir.pwd, file)
     File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
   end
+  sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
+  sig_files.each do |sig_path|
+    parts << File.mtime(sig_path).to_f.to_s
+  end
+  parts << sig_files.size.to_s
   Digest::MD5.hexdigest(parts.join(':'))
 end
 

--- a/lib/docscribe/server/base.rb
+++ b/lib/docscribe/server/base.rb
@@ -147,7 +147,8 @@ module Docscribe
         "#{socket_path(config_path)}.pid"
       end
 
-      ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml].freeze
+      ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml docscribe.yml].freeze
+      SIG_RBS_GLOB = 'sig/**/*.rbs'.freeze
 
       # @param [String] config_path
       # @return [String]
@@ -195,6 +196,7 @@ module Docscribe
 
       # Hash of environment files that affect analysis results.
       # When any of these change, the daemon is invalidated (new socket path).
+      # Includes Gemfile.lock, rbs_collection.lock.yaml, docscribe.yml and all sig/**/*.rbs.
       #
       # @return [String]
       def env_hash
@@ -202,7 +204,23 @@ module Docscribe
           path = File.join(Dir.pwd, file)
           File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
         end
+        sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
+        sig_files.each do |sig_path|
+          parts << File.mtime(sig_path).to_f.to_s
+        end
+        parts << sig_files.size.to_s
         Digest::MD5.hexdigest(parts.join(':'))
+      end
+
+      # Hash of RBS signature files for cache invalidation inside daemon.
+      # Used by Daemon#rewrite_file to detect sig changes without requiring a new socket.
+      #
+      # @return [String]
+      def sig_hash
+        sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
+        parts = sig_files.map { |p| "#{p}:#{File.mtime(p).to_f}" }
+        parts << "count:#{sig_files.size}"
+        Digest::MD5.hexdigest(parts.join('|'))
       end
 
       public :read_pid, :pid_path, :socket_path

--- a/lib/docscribe/server/base.rb
+++ b/lib/docscribe/server/base.rb
@@ -148,7 +148,7 @@ module Docscribe
       end
 
       ENV_FILES = %w[Gemfile.lock rbs_collection.lock.yaml docscribe.yml].freeze
-      SIG_RBS_GLOB = 'sig/**/*.rbs'.freeze
+      SIG_RBS_GLOB = 'sig/**/*.rbs'
 
       # @param [String] config_path
       # @return [String]
@@ -200,27 +200,40 @@ module Docscribe
       #
       # @return [String]
       def env_hash
-        parts = ENV_FILES.map do |file|
-          path = File.join(Dir.pwd, file)
-          File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
-        end
-        sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
-        sig_files.each do |sig_path|
-          parts << File.mtime(sig_path).to_f.to_s
-        end
-        parts << sig_files.size.to_s
+        parts = ENV_FILES.map { |file| env_file_mtime(file) }
+        parts.concat(sig_env_parts)
         Digest::MD5.hexdigest(parts.join(':'))
       end
 
       # Hash of RBS signature files for cache invalidation inside daemon.
       # Used by Daemon#rewrite_file to detect sig changes without requiring a new socket.
       #
-      # @return [Object]
+      # @return [String]
       def sig_hash
-        sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
-        parts = sig_files.map { |p| "#{p}:#{File.mtime(p).to_f}" }
-        parts << "count:#{sig_files.size}"
+        files = sig_files
+        parts = files.map { |p| "#{p}:#{File.mtime(p).to_f}" }
+        parts << "count:#{files.size}"
         Digest::MD5.hexdigest(parts.join('|'))
+      end
+
+      # @param [String] file
+      # @return [String]
+      def env_file_mtime(file)
+        path = File.join(Dir.pwd, file)
+        File.exist?(path) ? File.mtime(path).to_f.to_s : '0'
+      end
+
+      # @return [Array<String>]
+      def sig_env_parts
+        files = sig_files
+        mtimes = files.map { |p| File.mtime(p).to_f.to_s }
+        mtimes << files.size.to_s
+        mtimes
+      end
+
+      # @return [Array<String>]
+      def sig_files
+        Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
       end
 
       public :read_pid, :pid_path, :socket_path

--- a/lib/docscribe/server/base.rb
+++ b/lib/docscribe/server/base.rb
@@ -27,7 +27,7 @@ module Docscribe
     class << self
       # Start the server daemon if not running.
       #
-      # @param [String, nil] config_path optional config file path
+      # @param [String?] config_path optional config file path
       # @param [Boolean] daemonize redirect stdin/stdout/stderr to /dev/null
       # @param [Integer] timeout max seconds to wait for readiness
       # @return [void]
@@ -48,7 +48,7 @@ module Docscribe
 
       # Start the server daemon and wait for it to become ready.
       #
-      # @param [String, nil] config_path optional config path for socket/pid lookup
+      # @param [String?] config_path optional config path for socket/pid lookup
       # @param [Integer] timeout max seconds to wait for readiness
       # @param [Boolean] raise_on_timeout
       # @raise [StandardError]
@@ -75,7 +75,7 @@ module Docscribe
       # if yes, the daemon is still starting up (don't clean up);
       # if no, removes stale socket and pid files.
       #
-      # @param [String, nil] config_path optional config path for socket lookup
+      # @param [String?] config_path optional config path for socket lookup
       # @raise [Errno::ECONNREFUSED]
       # @raise [Errno::ENOENT]
       # @raise [Errno::ENOTSOCK]
@@ -101,7 +101,7 @@ module Docscribe
       # Handle ECONNREFUSED: check if the pid process is alive.
       # Cleans up only if the process is dead.
       #
-      # @param [String, nil] config_path
+      # @param [String?] config_path
       # @return [Boolean] false (not running)
       def handle_stale_socket?(config_path)
         pid = read_pid(config_path)
@@ -122,9 +122,9 @@ module Docscribe
         false
       end
 
-      # @param [String, nil] config_path
+      # @param [String?] config_path
       # @raise [StandardError]
-      # @return [Integer, nil]
+      # @return [Integer?]
       # @return [nil] if StandardError
       def read_pid(config_path = nil)
         File.read(pid_path(config_path)).to_i if File.exist?(pid_path(config_path))
@@ -134,14 +134,14 @@ module Docscribe
 
       # Remove stale socket and pid files.
       #
-      # @param [String, nil] config_path
+      # @param [String?] config_path
       # @return [void]
       def clean_socket_files(config_path)
         FileUtils.rm_f(socket_path(config_path))
         FileUtils.rm_f(pid_path(config_path))
       end
 
-      # @param [String, nil] config_path
+      # @param [String?] config_path
       # @return [String]
       def pid_path(config_path = nil)
         "#{socket_path(config_path)}.pid"
@@ -181,7 +181,7 @@ module Docscribe
       # Environment files (Gemfile.lock, rbs_collection.lock.yaml) are also
       # included so daemon is invalidated when gems or RBS types change.
       #
-      # @param [String, nil] config_path optional config path to differentiate
+      # @param [String?] config_path optional config path to differentiate
       # @return [String]
       def socket_path(config_path = nil)
         seed = +Dir.pwd
@@ -215,7 +215,7 @@ module Docscribe
       # Hash of RBS signature files for cache invalidation inside daemon.
       # Used by Daemon#rewrite_file to detect sig changes without requiring a new socket.
       #
-      # @return [String]
+      # @return [Object]
       def sig_hash
         sig_files = Dir.glob(File.join(Dir.pwd, SIG_RBS_GLOB)).sort
         parts = sig_files.map { |p| "#{p}:#{File.mtime(p).to_f}" }
@@ -225,7 +225,7 @@ module Docscribe
 
       public :read_pid, :pid_path, :socket_path
 
-      # @param [String, nil] config_path
+      # @param [String?] config_path
       # @param [Boolean] daemonize
       # @return [void]
       def start_daemon_process(config_path:, daemonize:)

--- a/lib/docscribe/server/client.rb
+++ b/lib/docscribe/server/client.rb
@@ -6,8 +6,8 @@ module Docscribe
   module Server
     # Client for communicating with a running Docscribe daemon.
     class Client
-      # @param [String, nil] socket_path custom socket path (defaults to server default)
-      # @param [String, nil] config_path optional config path for socket lookup
+      # @param [String?] socket_path custom socket path (defaults to server default)
+      # @param [String?] config_path optional config path for socket lookup
       # @return [void]
       def initialize(socket_path = nil, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
@@ -17,8 +17,8 @@ module Docscribe
       #
       # @param [String] file path to file to check
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
-      # @param [Hash<Symbol, Object>] rest extra JSON-RPC params (e.g. cli_overrides)
-      # @return [Hash<String, Object>, nil] response hash or nil if server unreachable
+      # @param [Object] rest extra JSON-RPC params (e.g. cli_overrides)
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def check(file:, strategy: :safe, **rest)
         request('check', file: file, strategy: strategy, **rest)
       end
@@ -27,22 +27,22 @@ module Docscribe
       #
       # @param [String] file path to file to fix
       # @param [Symbol] strategy rewrite strategy (:safe, :aggressive)
-      # @param [Hash<Symbol, Object>] rest extra JSON-RPC params (e.g. cli_overrides)
-      # @return [Hash<String, Object>, nil] response hash or nil if server unreachable
+      # @param [Object] rest extra JSON-RPC params (e.g. cli_overrides)
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def fix(file:, strategy: :safe, **rest)
         request('fix', file: file, strategy: strategy, **rest)
       end
 
       # Send a shutdown request to the server.
       #
-      # @return [Hash<String, Object>, nil] response hash or nil if server unreachable
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def shutdown
         request('shutdown')
       end
 
       # Ping the server and get version/pid/uptime info.
       #
-      # @return [Hash<String, Object>, nil] response hash or nil if server unreachable
+      # @return [Hash<String, Object>?] response hash or nil if server unreachable
       def ping
         request('ping')
       end
@@ -53,8 +53,8 @@ module Docscribe
       #
       # @private
       # @param [String] method method name
-      # @param [Hash<Symbol, Object>] params request parameters
-      # @return [Hash<String, Object>, nil]
+      # @param [Object] params request parameters
+      # @return [Hash<String, Object>?]
       def request(method, **params)
         connect do |socket|
           req = Protocol.build_request(method, params)
@@ -72,7 +72,7 @@ module Docscribe
       # @private
       # @raise [Errno::ECONNREFUSED]
       # @raise [Errno::ENOENT]
-      # @return [T, nil] yield return value or nil on connection error
+      # @return [U?] yield return value or nil on connection error
       def connect
         socket = UNIXSocket.new(@socket_path)
         yield socket

--- a/lib/docscribe/server/daemon.rb
+++ b/lib/docscribe/server/daemon.rb
@@ -4,6 +4,7 @@ require 'socket'
 require 'fileutils'
 require 'time'
 require 'timeout'
+require 'digest/md5'
 require_relative '../lru_cache'
 
 module Docscribe
@@ -33,6 +34,7 @@ module Docscribe
         @started_at = Time.now
         @cache_mutex = Mutex.new
         @config_mutex = Mutex.new
+        @last_sig_hash = nil
       end
 
       # Start the daemon: load dependencies, bind socket, enter listen loop.
@@ -298,11 +300,29 @@ module Docscribe
           config = @effective_config || @config or raise 'Docscribe: config not loaded'
           key = [file, strategy]
           mtime = File.mtime(file)
+          sig_hash = sig_hash_for(config)
+          if @last_sig_hash && @last_sig_hash != sig_hash
+            [@config, @effective_config].compact.each { |c| clear_rbs_cache(c) }
+            @file_cache.clear
+          end
+          @last_sig_hash = sig_hash
           hit = @file_cache[key]
-          return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime
+          return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime && hit[:sig_hash] == sig_hash
 
-          rewrite_and_cache(file, strategy, config, key, mtime)
+          rewrite_and_cache(file, strategy, config, key, mtime, sig_hash)
         end
+      end
+
+      # Clear memoized RBS providers so next request rebuilds env with fresh sig files.
+      #
+      # @private
+      # @param [Docscribe::Config] config
+      # @return [void]
+      def clear_rbs_cache(config)
+        config.instance_variable_set(:@rbs_provider, nil) if config.instance_variable_defined?(:@rbs_provider)
+        config.instance_variable_set(:@core_rbs_provider, nil) if config.instance_variable_defined?(:@core_rbs_provider)
+      rescue StandardError
+        nil
       end
 
       # @private
@@ -311,14 +331,44 @@ module Docscribe
       # @param [Docscribe::Config, nil] config effective or base config
       # @param [Array<(String, Symbol)>] key cache key
       # @param [Time] mtime file modification time
+      # @param [String] sig_hash hash of sig files mtimes
       # @return [(String, Hash<Symbol, Object>)]
-      def rewrite_and_cache(file, strategy, config, key, mtime)
+      def rewrite_and_cache(file, strategy, config, key, mtime, sig_hash)
         src = File.read(file)
         rbs = config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil
         result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: config,
                                                                     core_rbs_provider: rbs, file: file)
-        @file_cache[key] = { mtime: mtime, src: src, result: result }
+        @file_cache[key] = { mtime: mtime, sig_hash: sig_hash, src: src, result: result }
         [src, result]
+      end
+
+      # Hash of RBS signature files for cache invalidation.
+      # Includes all files under sig_dirs (default: sig/**/*.rbs).
+      #
+      # @private
+      # @param [Docscribe::Config] config effective or base config
+      # @return [String]
+      def sig_hash_for(config)
+        dirs = sig_dirs_for(config)
+        files = dirs.flat_map { |dir| Dir.glob(File.join(Dir.pwd, dir, '**', '*.rbs')) }.uniq.sort
+        parts = files.map { |p| "#{p}:#{File.mtime(p).to_f}" if File.file?(p) }.compact
+        parts << "count:#{files.size}"
+        Digest::MD5.hexdigest(parts.join('|'))
+      rescue StandardError
+        '0'
+      end
+
+      # Resolve sig dirs from config, falling back to defaults.
+      #
+      # @private
+      # @param [Docscribe::Config] config
+      # @return [Array<String>]
+      def sig_dirs_for(config)
+        raw_dirs = config.raw.dig('rbs', 'sig_dirs') if config.respond_to?(:raw)
+        dirs = Array(raw_dirs || Docscribe::Config::DEFAULT.dig('rbs', 'sig_dirs')).map(&:to_s)
+        dirs.empty? ? ['sig'] : dirs
+      rescue StandardError
+        ['sig']
       end
 
       # Handle a shutdown request.

--- a/lib/docscribe/server/daemon.rb
+++ b/lib/docscribe/server/daemon.rb
@@ -19,11 +19,12 @@ module Docscribe
         timeout: -32_010,
         internal: -32_099
       }.freeze
+
       # @param [String?] socket_path custom socket path
       # @param [Integer] idle_timeout seconds before automatic shutdown
       # @param [String?] config_path custom config path
       # @return [void]
-      def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
+      def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil) # rubocop:disable Metrics/MethodLength
         @socket_path = socket_path || Server.socket_path(config_path)
         @idle_timeout = idle_timeout
         @config_path = config_path
@@ -301,24 +302,43 @@ module Docscribe
           key = [file, strategy]
           mtime = File.mtime(file)
           sig_hash = sig_hash_for(config)
-          if @last_sig_hash && @last_sig_hash != sig_hash
-            [@config, @effective_config].compact.each { |c| clear_rbs_cache(c) }
-            @file_cache.clear
-          end
-          @last_sig_hash = sig_hash
-          hit = @file_cache[key]
-          return [hit[:src], hit[:result]] if hit && hit[:mtime] == mtime && hit[:sig_hash] == sig_hash
+          handle_sig_change(sig_hash)
+          cached = cached_result(key, mtime, sig_hash)
+          return cached if cached
 
-          rewrite_and_cache(file, strategy, config, key, mtime, sig_hash)
+          rewrite_and_cache(file, strategy, config, key, mtime)
         end
+      end
+
+      # @private
+      # @param [String] sig_hash
+      # @return [void]
+      def handle_sig_change(sig_hash)
+        if @last_sig_hash && @last_sig_hash != sig_hash
+          [@config, @effective_config].compact.each { |c| clear_rbs_cache(c) }
+          @file_cache.clear
+        end
+        @last_sig_hash = sig_hash
+      end
+
+      # @private
+      # @param [Array<String, Symbol>] key
+      # @param [Time] mtime
+      # @param [String] sig_hash
+      # @return [(String, Hash<Symbol, String, Array<Hash<Symbol, Object>>>)?]
+      def cached_result(key, mtime, sig_hash)
+        hit = @file_cache[key]
+        return nil unless hit && hit[:mtime] == mtime && hit[:sig_hash] == sig_hash
+
+        [hit[:src], hit[:result]]
       end
 
       # Clear memoized RBS providers so next request rebuilds env with fresh sig files.
       #
       # @private
-      # @param [Object] config
+      # @param [Docscribe::Config] config
       # @raise [StandardError]
-      # @return [T?]
+      # @return [void]
       # @return [nil] if StandardError
       def clear_rbs_cache(config)
         config.instance_variable_set(:@rbs_provider, nil) if config.instance_variable_defined?(:@rbs_provider)
@@ -333,14 +353,13 @@ module Docscribe
       # @param [Docscribe::Config] config effective or base config
       # @param [Array<String, Symbol>] key cache key
       # @param [Time] mtime file modification time
-      # @param [Object] sig_hash hash of sig files mtimes
       # @return [(String, Hash<Symbol, String, Array<Hash<Symbol, Object>>>)]
-      def rewrite_and_cache(file, strategy, config, key, mtime, sig_hash)
+      def rewrite_and_cache(file, strategy, config, key, mtime)
         src = File.read(file)
         rbs = config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil
         result = Docscribe::InlineRewriter.rewrite_with_report(src, strategy: strategy, config: config,
                                                                     core_rbs_provider: rbs, file: file)
-        @file_cache[key] = { mtime: mtime, sig_hash: sig_hash, src: src, result: result }
+        @file_cache[key] = { mtime: mtime, sig_hash: @last_sig_hash, src: src, result: result }
         [src, result]
       end
 
@@ -348,13 +367,12 @@ module Docscribe
       # Includes all files under sig_dirs (default: sig/**/*.rbs).
       #
       # @private
-      # @param [Object] config effective or base config
+      # @param [Docscribe::Config] config effective or base config
       # @raise [StandardError]
-      # @return [Object]
+      # @return [String]
       # @return [String] if StandardError
       def sig_hash_for(config)
-        dirs = sig_dirs_for(config)
-        files = dirs.flat_map { |dir| Dir.glob(File.join(Dir.pwd, dir, '**', '*.rbs')) }.uniq.sort
+        files = sig_rbs_files(sig_dirs_for(config))
         parts = files.map { |p| "#{p}:#{File.mtime(p).to_f}" if File.file?(p) }.compact
         parts << "count:#{files.size}"
         Digest::MD5.hexdigest(parts.join('|'))
@@ -362,16 +380,23 @@ module Docscribe
         '0'
       end
 
+      # @private
+      # @param [Array<String>] dirs
+      # @return [Array<String>]
+      def sig_rbs_files(dirs)
+        dirs.flat_map { |dir| Dir.glob(File.join(Dir.pwd, dir, '**', '*.rbs')) }.uniq.sort
+      end
+
       # Resolve sig dirs from config, falling back to defaults.
       #
       # @private
-      # @param [Object] config
+      # @param [Docscribe::Config] config
       # @raise [StandardError]
-      # @return [Array, Object]
+      # @return [Array<String>]
       # @return [Array] if StandardError
       def sig_dirs_for(config)
         raw_dirs = config.raw.dig('rbs', 'sig_dirs') if config.respond_to?(:raw)
-        dirs = Array(raw_dirs || Docscribe::Config::DEFAULT.dig('rbs', 'sig_dirs')).map(&:to_s)
+        dirs = Array(raw_dirs || Docscribe::Config::DEFAULT.dig('rbs', 'sig_dirs')).map(&:to_s) # steep:ignore
         dirs.empty? ? ['sig'] : dirs
       rescue StandardError
         ['sig']

--- a/lib/docscribe/server/daemon.rb
+++ b/lib/docscribe/server/daemon.rb
@@ -19,9 +19,9 @@ module Docscribe
         timeout: -32_010,
         internal: -32_099
       }.freeze
-      # @param [String, nil] socket_path custom socket path
+      # @param [String?] socket_path custom socket path
       # @param [Integer] idle_timeout seconds before automatic shutdown
-      # @param [String, nil] config_path custom config path
+      # @param [String?] config_path custom config path
       # @return [void]
       def initialize(socket_path: nil, idle_timeout: IDLE_TIMEOUT, config_path: nil)
         @socket_path = socket_path || Server.socket_path(config_path)
@@ -221,10 +221,10 @@ module Docscribe
       # @private
       # @param [String] file
       # @param [Symbol] strategy
-      # @param [Integer, Float, nil] timeout
+      # @param [Integer, Float?] timeout
       # @raise [Timeout::Error]
       # @raise [StandardError]
-      # @return [Hash<String, Object>]
+      # @return [Hash<String, String, Array<Hash<Symbol, Object>>>]
       # @return [Hash] if Timeout::Error
       # @return [Hash] if StandardError
       def process_file_in_batch(file, strategy, timeout = nil)
@@ -244,14 +244,14 @@ module Docscribe
       # @private
       # @param [String] file
       # @param [Symbol] strategy
-      # @return [Hash<String, Object>]
+      # @return [Hash<String, String, Array<Hash<Symbol, Object>>>]
       def run_rewrite(file, strategy)
         src, result = rewrite_file(file, strategy)
         { 'file' => file, 'status' => result[:output] == src ? 'ok' : 'fail', 'changes' => result[:changes] }
       end
 
       # @private
-      # @param [Hash<String, Object>, nil] overrides
+      # @param [Hash<String, Object>?] overrides
       # @return [void]
       def apply_cli_overrides(overrides)
         @config_mutex.synchronize do
@@ -294,7 +294,7 @@ module Docscribe
       # @param [String] file
       # @param [Symbol] strategy
       # @raise [StandardError]
-      # @return [(String, Hash<Symbol, Object>)]
+      # @return [(String, Hash<Symbol, String, Array<Hash<Symbol, Object>>>)]
       def rewrite_file(file, strategy)
         @cache_mutex.synchronize do
           config = @effective_config || @config or raise 'Docscribe: config not loaded'
@@ -316,8 +316,10 @@ module Docscribe
       # Clear memoized RBS providers so next request rebuilds env with fresh sig files.
       #
       # @private
-      # @param [Docscribe::Config] config
-      # @return [void]
+      # @param [Object] config
+      # @raise [StandardError]
+      # @return [T?]
+      # @return [nil] if StandardError
       def clear_rbs_cache(config)
         config.instance_variable_set(:@rbs_provider, nil) if config.instance_variable_defined?(:@rbs_provider)
         config.instance_variable_set(:@core_rbs_provider, nil) if config.instance_variable_defined?(:@core_rbs_provider)
@@ -328,11 +330,11 @@ module Docscribe
       # @private
       # @param [String] file
       # @param [Symbol] strategy
-      # @param [Docscribe::Config, nil] config effective or base config
-      # @param [Array<(String, Symbol)>] key cache key
+      # @param [Docscribe::Config] config effective or base config
+      # @param [Array<String, Symbol>] key cache key
       # @param [Time] mtime file modification time
-      # @param [String] sig_hash hash of sig files mtimes
-      # @return [(String, Hash<Symbol, Object>)]
+      # @param [Object] sig_hash hash of sig files mtimes
+      # @return [(String, Hash<Symbol, String, Array<Hash<Symbol, Object>>>)]
       def rewrite_and_cache(file, strategy, config, key, mtime, sig_hash)
         src = File.read(file)
         rbs = config.respond_to?(:core_rbs_provider) ? config.core_rbs_provider : nil
@@ -346,8 +348,10 @@ module Docscribe
       # Includes all files under sig_dirs (default: sig/**/*.rbs).
       #
       # @private
-      # @param [Docscribe::Config] config effective or base config
-      # @return [String]
+      # @param [Object] config effective or base config
+      # @raise [StandardError]
+      # @return [Object]
+      # @return [String] if StandardError
       def sig_hash_for(config)
         dirs = sig_dirs_for(config)
         files = dirs.flat_map { |dir| Dir.glob(File.join(Dir.pwd, dir, '**', '*.rbs')) }.uniq.sort
@@ -361,8 +365,10 @@ module Docscribe
       # Resolve sig dirs from config, falling back to defaults.
       #
       # @private
-      # @param [Docscribe::Config] config
-      # @return [Array<String>]
+      # @param [Object] config
+      # @raise [StandardError]
+      # @return [Array, Object]
+      # @return [Array] if StandardError
       def sig_dirs_for(config)
         raw_dirs = config.raw.dig('rbs', 'sig_dirs') if config.respond_to?(:raw)
         dirs = Array(raw_dirs || Docscribe::Config::DEFAULT.dig('rbs', 'sig_dirs')).map(&:to_s)
@@ -413,9 +419,9 @@ module Docscribe
 
       # @private
       # @param [Exception] exception
-      # @param [String, nil] _method_name
+      # @param [String?] _method_name
       # @param [Hash<String, Object>] params
-      # @return [(Integer, String, Object)]
+      # @return [(Integer, String, Hash<Symbol, Object, nil>, nil)]
       def classify_error(exception, _method_name = nil, params = {})
         if exception.is_a?(LoadError) || exception.is_a?(Gem::LoadError)
           classify_gem_error(exception)
@@ -444,8 +450,8 @@ module Docscribe
       end
 
       # @private
-      # @param [Exception] exception
-      # @return [(Integer, String, Hash<Symbol, String>)]
+      # @param [Object] exception
+      # @return [(Integer, String, Hash<Symbol, String, nil>)]
       def classify_gem_error(exception)
         data = { gem: nil }
         data[:gem] = exception.path if exception.respond_to?(:path) && exception.path
@@ -453,7 +459,7 @@ module Docscribe
       end
 
       # @private
-      # @param [Exception] exception
+      # @param [Object] exception
       # @param [Hash<String, Object>] params
       # @return [(Integer, String, Hash<Symbol, Object>)]
       def classify_syntax_err(exception, params)
@@ -489,7 +495,7 @@ module Docscribe
       # @private
       # @param [UNIXSocket] client
       # @param [String, Integer] id
-      # @param [Exception] exception
+      # @param [Object] exception
       # @param [String] file
       # @raise [StandardError]
       # @return [void]
@@ -505,7 +511,7 @@ module Docscribe
       # @private
       # @param [UNIXSocket] client
       # @param [String, Integer] id
-      # @param [Exception] exception
+      # @param [Object] exception
       # @param [String] file
       # @return [void]
       def send_syntax_error(client, id, exception, file)
@@ -523,7 +529,7 @@ module Docscribe
       # @param [String, Integer, nil] id
       # @param [Integer] code
       # @param [String] message
-      # @param [Hash<Symbol, Object>, nil] data optional structured error data
+      # @param [Object?] data optional structured error data
       # @return [void]
       def send_error(client, id, code, message, data = nil)
         error = { code: code, message: message }

--- a/lib/docscribe/server/protocol.rb
+++ b/lib/docscribe/server/protocol.rb
@@ -13,8 +13,8 @@ module Docscribe
       #
       # @note module_function: defines #build_request (visibility: private)
       # @param [String] method method name
-      # @param [Hash<Symbol, Object>] params request parameters
-      # @return [Hash<Symbol, Object>]
+      # @param [Hash<Symbol, T>] params request parameters
+      # @return [Hash<Symbol, String, Hash<Symbol, T>>]
       def build_request(method, params = {})
         {
           jsonrpc: '2.0',
@@ -29,7 +29,7 @@ module Docscribe
       # @note module_function: defines #parse_response (visibility: private)
       # @param [String] line raw JSON line
       # @raise [JSON::ParserError]
-      # @return [Hash<String, Object>, nil]
+      # @return [Hash<String, Object>?]
       # @return [nil] if JSON::ParserError
       def parse_response(line)
         JSON.parse(line)
@@ -40,7 +40,7 @@ module Docscribe
       # Serialize a hash to a JSON line.
       #
       # @note module_function: defines #serialize (visibility: private)
-      # @param [Hash<Object, Object>] hash
+      # @param [Object] hash
       # @return [String]
       def serialize(hash)
         "#{JSON.generate(hash)}\n"

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: diff-lcs
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: parser
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -94,7 +94,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -102,7 +102,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: random-formatter
@@ -122,7 +122,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ripper
@@ -134,7 +134,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-ast
@@ -142,7 +142,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rubocop-sorted_methods_by_call
@@ -170,7 +170,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea56a88d1c0ac98e79f8ea5bb19a139da768ba10
+    revision: 9ab762c8247028f90620fc93c4e7aac20eb693d7
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/sig/lib/docscribe/server/base.rbs
+++ b/sig/lib/docscribe/server/base.rbs
@@ -9,6 +9,7 @@ module Docscribe
     SOCKET_DIR: String
     IDLE_TIMEOUT: Integer
     ENV_FILES: Array[String]
+    SIG_RBS_GLOB: String
 
     def self?.running?: (?String? config_path) -> bool
     def self?.read_pid: (?String? config_path) -> Integer?
@@ -16,6 +17,10 @@ module Docscribe
     def self?.socket_path: (?String? config_path) -> String
     def self?.config_hash: (String config_path) -> String
     def self?.env_hash: () -> String
+    def self?.sig_hash: () -> String
+    def self?.env_file_mtime: (String) -> String
+    def self?.sig_files: () -> Array[String]
+    def self?.sig_env_parts: () -> Array[String]
     def self?.check_platform_support!: () -> void
     def self?.ensure_running!: (?config_path: String?, ?daemonize: bool, ?timeout: Integer) -> void
     def self?.wait_for_ready: (?config_path: String?, ?timeout: Integer, ?raise_on_timeout: bool) -> bool

--- a/sig/lib/docscribe/server/daemon.rbs
+++ b/sig/lib/docscribe/server/daemon.rbs
@@ -41,6 +41,7 @@ module Docscribe
       @config_mutex: Mutex
       @started_at: Time
       @applied_overrides: (Hash[String, Object] | nil)
+      @last_sig_hash: (String | nil)
 
       ERROR_CODES: Hash[Symbol, Integer]
 
@@ -67,7 +68,13 @@ module Docscribe
       def reset_effective_config: () -> void
       def reset_effective_config_internal: () -> void
       def rewrite_file: (String, Symbol) -> [String, { output: String, changes: Array[Hash[Symbol, untyped]] }]
+      def handle_sig_change: (String) -> void
+      def cached_result: (Array[(String | Symbol)], Time, String) -> [String, { output: String, changes: Array[Hash[Symbol, untyped]] }]?
+      def clear_rbs_cache: (Docscribe::Config) -> void
       def rewrite_and_cache: (String, Symbol, Docscribe::Config, Array[(String | Symbol)], Time) -> [String, { output: String, changes: Array[Hash[Symbol, untyped]] }]
+      def sig_hash_for: (Docscribe::Config) -> String
+      def sig_rbs_files: (Array[String]) -> Array[String]
+      def sig_dirs_for: (Docscribe::Config) -> Array[String]
       def handle_shutdown: (UNIXSocket, (String | Integer)) -> void
       def handle_ping: (UNIXSocket, (String | Integer)) -> void
       def send_result: (UNIXSocket, (String | Integer), Hash[String, Object]) -> void

--- a/spec/docscribe/server/base_spec.rb
+++ b/spec/docscribe/server/base_spec.rb
@@ -165,4 +165,97 @@ RSpec.describe Docscribe::Server do
       expect(File.exist?(sock)).to be false
     end
   end
+
+  # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/IdenticalEqualityAssertion
+  describe '.env_hash' do
+    around { |ex| Dir.mktmpdir { |t| Dir.chdir(t, &ex) } }
+
+    it 'returns consistent hash when no sig files' do
+      expect(described_class.send(:env_hash)).to eq(described_class.send(:env_hash))
+    end
+
+    it 'changes when sig file content changes' do
+      FileUtils.mkdir_p('sig')
+      File.write('sig/a.rbs', 'class A; def foo: () -> Integer; end')
+      h1 = described_class.send(:env_hash)
+      sleep 0.02
+      File.write('sig/a.rbs', 'class A; def foo: () -> String; end')
+      h2 = described_class.send(:env_hash)
+      expect(h1).not_to eq(h2)
+    end
+
+    it 'changes when new sig file is added' do
+      FileUtils.mkdir_p('sig')
+      h1 = described_class.send(:env_hash)
+      File.write('sig/b.rbs', 'class B; end')
+      h2 = described_class.send(:env_hash)
+      expect(h1).not_to eq(h2)
+    end
+
+    it 'changes when sig file is removed' do
+      FileUtils.mkdir_p('sig')
+      File.write('sig/c.rbs', 'class C; end')
+      h1 = described_class.send(:env_hash)
+      FileUtils.rm('sig/c.rbs')
+      h2 = described_class.send(:env_hash)
+      expect(h1).not_to eq(h2)
+    end
+
+    it 'includes docscribe.yml' do
+      h1 = described_class.send(:env_hash)
+      File.write('docscribe.yml', 'rbs: {enabled: true}')
+      h2 = described_class.send(:env_hash)
+      expect(h1).not_to eq(h2)
+      FileUtils.rm('docscribe.yml')
+      expect(described_class.send(:env_hash)).to eq(h1)
+    end
+  end
+
+  describe '.sig_hash' do
+    around { |ex| Dir.mktmpdir { |t| Dir.chdir(t, &ex) } }
+
+    it 'changes when sig file mtime changes' do
+      FileUtils.mkdir_p('sig')
+      File.write('sig/x.rbs', 'class X; end')
+      h1 = described_class.sig_hash
+      sleep 0.02
+      File.write('sig/x.rbs', 'class X; def bar: () -> String; end')
+      h2 = described_class.sig_hash
+      expect(h1).not_to eq(h2)
+    end
+
+    it 'is stable without changes' do
+      expect(described_class.sig_hash).to eq(described_class.sig_hash)
+    end
+
+    it 'changes when sig file count changes' do
+      FileUtils.mkdir_p('sig')
+      h1 = described_class.sig_hash
+      File.write('sig/y.rbs', 'class Y; end')
+      h2 = described_class.sig_hash
+      expect(h1).not_to eq(h2)
+    end
+  end
+
+  describe '.socket_path with sig and docscribe.yml' do
+    around { |ex| Dir.mktmpdir { |t| Dir.chdir(t, &ex) } }
+
+    it 'changes when sig file changes' do
+      FileUtils.mkdir_p('sig')
+      File.write('sig/a.rbs', 'class A; end')
+      s1 = described_class.socket_path
+      sleep 0.02
+      File.write('sig/a.rbs', 'class A; def foo: () -> Integer; end')
+      s2 = described_class.socket_path
+      expect(s1).not_to eq(s2)
+    end
+
+    it 'changes when docscribe.yml changes' do
+      s1 = described_class.socket_path
+      File.write('docscribe.yml', 'rbs: {enabled: false}')
+      s2 = described_class.socket_path
+      expect(s1).not_to eq(s2)
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/IdenticalEqualityAssertion
 end

--- a/spec/docscribe/server/daemon_spec.rb
+++ b/spec/docscribe/server/daemon_spec.rb
@@ -215,4 +215,98 @@ RSpec.describe Docscribe::Server::Daemon do
       end
     end
   end
+
+  # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+  describe 'rbs sig cache invalidation' do
+    context 'when RBS is available' do
+      before { skip_unless_rbs_available! }
+
+      it 'invalidates cache when sig file changes without touching ruby file' do
+        with_tmp_dir do |dir|
+          daemon = build_sig_daemon(dir, rbs: DaemonSigHelper::DEMO_RBS_INTEGER)
+          write_ruby("#{dir}/a.rb")
+          r1 = rbs_rewrite(daemon, "#{dir}/a.rb")
+          expect(r1).to include('@param [Integer]')
+          update_sig('sig/demo.rbs', DaemonSigHelper::DEMO_RBS_STRING)
+          r2 = rbs_rewrite(daemon, "#{dir}/a.rb")
+          expect(r2).to include('@param [String]')
+          expect(r1).not_to eq(r2)
+        end
+      end
+
+      it 'invalidates cache for new file after sig change' do
+        with_tmp_dir do |dir|
+          daemon = build_sig_daemon(dir)
+          write_ruby("#{dir}/a.rb")
+          write_ruby("#{dir}/b.rb")
+          r1 = rbs_rewrite(daemon, "#{dir}/a.rb")
+          expect(r1).to include('@param [Integer]')
+          update_sig('sig/demo.rbs', DaemonSigHelper::DEMO_RBS_STRING)
+          r2 = rbs_rewrite(daemon, "#{dir}/b.rb")
+          expect(r2).to include('@param [String]')
+        end
+      end
+
+      it 'caches again after sig change' do
+        with_tmp_dir do |dir|
+          daemon = build_sig_daemon(dir)
+          write_ruby("#{dir}/a.rb")
+          r1 = rbs_rewrite(daemon, "#{dir}/a.rb")
+          update_sig('sig/demo.rbs', DaemonSigHelper::DEMO_RBS_STRING)
+          r2 = rbs_rewrite(daemon, "#{dir}/a.rb")
+          allow(Docscribe::InlineRewriter).to receive(:rewrite_with_report) { raise 'should be cached' }
+          r3 = rbs_rewrite(daemon, "#{dir}/a.rb")
+          expect(r3).to eq(r2)
+          expect(r1).not_to eq(r3)
+        end
+      end
+    end
+
+    context 'without RBS dependency' do
+      it 'stores sig_hash in cache entry' do
+        with_tmp_dir do |dir|
+          prepare_sig_files('sig/a.rbs', "class A\nend\n")
+          write_ruby("#{dir}/x.rb", "class A\n  def foo; end\nend\n")
+          daemon = build_plain_daemon(dir)
+          daemon.send(:apply_cli_overrides, rbs_overrides)
+          daemon.send(:rewrite_file, "#{dir}/x.rb", :safe)
+          hit = daemon.instance_variable_get(:@file_cache)[["#{dir}/x.rb", :safe]]
+          expect(hit).to include(:sig_hash)
+          config = daemon.instance_variable_get(:@effective_config) || daemon.instance_variable_get(:@config)
+          expect(hit[:sig_hash]).to eq(daemon.send(:sig_hash_for, config))
+        end
+      end
+
+      it 'sig_hash_for respects custom sig_dirs' do
+        with_tmp_dir do |dir|
+          prepare_sig_files('custom_sig/b.rbs', "class B\nend\n", 'sig/a.rbs', "class A\nend\n")
+          daemon = build_plain_daemon(dir)
+          h_custom = sig_hash_for_config(daemon, ['custom_sig'])
+          h_default = sig_hash_for_config(daemon, ['sig'])
+          expect(h_custom).not_to eq(h_default)
+        end
+      end
+
+      it 'sig_dirs_for falls back to sig when empty' do
+        with_tmp_dir do |dir|
+          daemon = build_plain_daemon(dir)
+          config = Docscribe::Config.new('rbs' => { 'enabled' => true, 'sig_dirs' => [] })
+          expect(daemon.send(:sig_dirs_for, config)).to eq(['sig'])
+        end
+      end
+
+      it 'sig_hash changes when new sig file added' do
+        with_tmp_dir do |dir|
+          prepare_sig_files('sig/a.rbs', "class A\nend\n")
+          daemon = build_plain_daemon(dir)
+          config = Docscribe::Config.new('rbs' => { 'enabled' => true, 'sig_dirs' => ['sig'] })
+          h1 = daemon.send(:sig_hash_for, config)
+          write_sig('sig/b.rbs', "class B\nend\n")
+          h2 = daemon.send(:sig_hash_for, config)
+          expect(h1).not_to eq(h2)
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,7 @@ RSpec.configure do |config|
   config.include CleanFileHelper
   config.include ServerWireHelper
   config.include DaemonHelper
+  config.include DaemonSigHelper
   config.example_status_persistence_file_path = '.rspec_status'
   config.disable_monkey_patching!
   config.expect_with(:rspec) { |c| c.syntax = :expect }

--- a/spec/support/daemon_sig_helper.rb
+++ b/spec/support/daemon_sig_helper.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module DaemonSigHelper
+  DEMO_RBS_INTEGER = "class Demo\n  def foo: (Integer x) -> Integer\nend\n"
+  DEMO_RBS_STRING = "class Demo\n  def foo: (String x) -> String\nend\n"
+  DEMO_RUBY = "class Demo\n  def foo(x)\n    x\n  end\nend\n"
+
+  # Method documentation.
+  #
+  # @return [Object]
+  def with_tmp_dir
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) { yield dir }
+    end
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] path Param documentation.
+  # @param [DEMO_RUBY] content Param documentation.
+  # @return [Object]
+  def write_ruby(path, content = DEMO_RUBY)
+    File.write(path, content)
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] dir Param documentation.
+  # @param [DEMO_RBS_INTEGER] rbs Param documentation.
+  # @return [Object]
+  def build_sig_daemon(dir, rbs: DEMO_RBS_INTEGER)
+    FileUtils.mkdir_p('sig')
+    File.write('sig/demo.rbs', rbs) if rbs
+    daemon = described_class.new(socket_path: "#{dir}/test.sock", idle_timeout: 60)
+    daemon.send(:load_dependencies)
+    daemon.send(:apply_cli_overrides, rbs_overrides)
+    daemon
+  end
+
+  # Method documentation.
+  #
+  # @return [Hash]
+  def rbs_overrides
+    {
+      'rbs' => true,
+      'sig_dirs' => [],
+      'rbi_dirs' => [],
+      'include' => [],
+      'exclude' => [],
+      'include_file' => [],
+      'exclude_file' => [],
+      'no_boilerplate' => false
+    }
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] daemon Param documentation.
+  # @param [Object] sig_dirs Param documentation.
+  # @return [Object]
+  def sig_hash_for_config(daemon, sig_dirs)
+    config = Docscribe::Config.new('rbs' => { 'enabled' => true, 'sig_dirs' => sig_dirs })
+    daemon.send(:sig_hash_for, config)
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] path Param documentation.
+  # @param [Object] content Param documentation.
+  # @param [Float] delay Param documentation.
+  # @return [Object]
+  def update_sig(path, content, delay: 0.05)
+    sleep delay
+    write_sig(path, content)
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] daemon Param documentation.
+  # @param [Object] file Param documentation.
+  # @param [Symbol] strategy Param documentation.
+  # @return [Object]
+  def rbs_rewrite(daemon, file, strategy: :safe)
+    _src, result = daemon.send(:rewrite_file, file, strategy)
+    result[:output]
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] dir Param documentation.
+  # @param [String] socket Param documentation.
+  # @return [Object]
+  def build_plain_daemon(dir, socket: 's.sock')
+    daemon = described_class.new(socket_path: "#{dir}/#{socket}", idle_timeout: 60)
+    daemon.send(:load_dependencies)
+    daemon
+  end
+
+  # Method documentation.
+  #
+  # @param [Array] paths_and_contents Param documentation.
+  # @return [Object]
+  def prepare_sig_files(*paths_and_contents)
+    paths_and_contents.each_slice(2) do |path, content|
+      write_sig(path, content)
+    end
+  end
+
+  # Method documentation.
+  #
+  # @param [Object] path Param documentation.
+  # @param [Object] content Param documentation.
+  # @return [Object]
+  def write_sig(path, content)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+end

--- a/spec/support/rbs_helper.rb
+++ b/spec/support/rbs_helper.rb
@@ -45,6 +45,7 @@ module RbsHelper
   # @param [String] code Ruby source to rewrite
   # @param [String] rbs RBS file content
   # @param [String] sig_dir_name relative path for the sig directory
+  # @param [Hash] config Param documentation.
   # @return [String] rewritten source
   def inline_with_rbs(code:, rbs:, sig_dir_name: 'sig', config: {})
     skip_unless_rbs_available!
@@ -61,6 +62,12 @@ module RbsHelper
     end
   end
 
+  # Method documentation.
+  #
+  # @param [Object] source Param documentation.
+  # @param [Array] extra Param documentation.
+  # @param [String] filename Param documentation.
+  # @return [Object]
   def rbs_out(source, *extra, filename: 'test.rb')
     Dir.mktmpdir do |dir|
       path = File.join(dir, filename)
@@ -69,6 +76,11 @@ module RbsHelper
     end
   end
 
+  # Method documentation.
+  #
+  # @param [Object] source Param documentation.
+  # @param [String] filename Param documentation.
+  # @return [Object]
   def with_rbs(source, filename: 'test.rb')
     Dir.mktmpdir do |dir|
       path = File.join(dir, filename)
@@ -77,6 +89,12 @@ module RbsHelper
     end
   end
 
+  # Method documentation.
+  #
+  # @param [Object] rb_source Param documentation.
+  # @param [Object] old_content Param documentation.
+  # @param [String] sig_name Param documentation.
+  # @return [Object]
   def with_existing_rbs(rb_source, old_content, sig_name: 'test.rbs')
     Dir.mktmpdir do |dir|
       path = File.join(dir, 'test.rb')
@@ -92,6 +110,12 @@ module RbsHelper
   # Skip the example if the RBS gem is unavailable.
   #
   # Call this at the top of any example that depends on RBS bridge parsing.
+  # Method documentation.
+  #
+  # @private
+  # @raise [LoadError]
+  # @return [Object]
+  # @return [Object] if LoadError
   def skip_unless_rbs_available!
     require 'rbs'
   rescue LoadError
@@ -101,6 +125,11 @@ module RbsHelper
   # Skip the example if the RBS gem or RubyVM::AbstractSyntaxTree is unavailable.
   #
   # Call this at the top of any example that depends on Sorbet/RBS bridge parsing.
+  # Method documentation.
+  #
+  # @private
+  # @raise [LoadError]
+  # @return [Object]
   def skip_unless_sorbet_bridge_available!
     begin
       require 'rbs'
@@ -111,6 +140,13 @@ module RbsHelper
     skip 'RubyVM::AbstractSyntaxTree not available' unless defined?(RubyVM::AbstractSyntaxTree)
   end
 
+  # Method documentation.
+  #
+  # @private
+  # @param [Object] dir Param documentation.
+  # @param [Object] sig_dir_name Param documentation.
+  # @param [Object] rbs_content Param documentation.
+  # @return [Hash]
   def rbs_config(dir, sig_dir_name, rbs_content)
     sig_dir = File.join(dir, sig_dir_name)
     FileUtils.mkdir_p(sig_dir)


### PR DESCRIPTION
## Summary

Fix daemon file-cache staleness when RBS signatures change without changing the Ruby file or `cli_overrides`.

## Problem

`Server::Daemon#rewrite_file` cached by `[file, strategy] + mtime` and cleared the cache only when `cli_overrides` changed (`@applied_overrides == overrides`). When both consecutive checks used `rbs: true` and only `sig/**/*.rbs` content changed, the daemon returned a stale result (e.g. `Object` instead of `Integer`) and reused a stale `RBS::Provider` env.

Similarly `Server.socket_path`/`env_hash` only hashed `Gemfile.lock` and `rbs_collection.lock.yaml`, so changing `sig/**/*.rbs` or `docscribe.yml` did not invalidate the daemon via a new socket.

## Solution

**`lib/docscribe/server/base.rb`**
- `ENV_FILES` now includes `docscribe.yml`.
- `SIG_RBS_GLOB = 'sig/**/*.rbs'`.
- `env_hash` hashes mtimes of `ENV_FILES` plus all `sig/**/*.rbs` files and their count -> new socket path on sig/docscribe.yml change.
- Added `Server.sig_hash` helper.

**`lib/docscribe/server/daemon.rb`**
- Store `sig_hash` per cache entry (`mtime + sig_hash`) and per-request `@last_sig_hash`.
- `sig_hash_for(config)` hashes all files under `sig_dirs` (from `config.raw['rbs']['sig_dirs']` or `DEFAULT`) with mtimes + count.
- On `sig_hash` change: `clear_rbs_cache` for `@config`/`@effective_config` (`@rbs_provider`/`@core_rbs_provider = nil` -> fresh `RBS::Environment` on next request) and `clear` file cache.
- `rewrite_file` and `rewrite_and_cache` now validate `sig_hash` alongside `mtime`.

**`exe/docscribe-client`**
- Synced `ENV_FILES`, `SIG_RBS_GLOB` and `env_hash` logic with `Server` to avoid socket mismatch for the thin client.

## Verification

- `bundle exec rspec spec/docscribe/server` (56) and `spec/docscribe/cli/server_spec.rb:207` pass.
- Manual: create `sig/demo.rbs` with `def foo: (Integer x) -> Integer`, check `test.rb` via daemon with `rbs: true` -> `@param [Integer]`; change RBS to `(String x) -> String` without touching Ruby file -> next `check` with same `rbs: true` immediately returns `@param [String]` (previously stale). New files after sig change also see fresh types; third consecutive check is correctly cached.
- `env_hash`/`socket_path` change after modifying `sig/*.rbs` or `docscribe.yml`.

## Risk

No breaking change. Socket path changes after sig/docscribe.yml modifications will spawn a new daemon; old daemon idles out after `IDLE_TIMEOUT`.