### PR TITLE
[1.6.2] Fix invalid YARD safe fix and void/Boolean union

### DIFF
--- a/examples/plugins/collector_plugin/schema_attributes/plugin.rb
+++ b/examples/plugins/collector_plugin/schema_attributes/plugin.rb
@@ -293,11 +293,7 @@ module DocscribePlugins
     # @param [Object] col_name
     # @return [Object]
     def recognized_column?(col_type, col_name)
-      RECOGNIZED_COLUMNS.include?(col_type.to_sym) &&
-        !SKIPPED_COLUMNS.include?(col_name)
-      enddef recognized_column?(col_type, col_name)
-      RECOGNIZED_COLUMNS.include?(col_type.to_sym) &&
-        !SKIPPED_COLUMNS.include?(col_name)
+      RECOGNIZED_COLUMNS.include?(col_type.to_sym) && !SKIPPED_COLUMNS.include?(col_name)
     end
 
     # Build @!attribute doc blocks for all columns of a table.

--- a/lib/docscribe/inline_rewriter.rb
+++ b/lib/docscribe/inline_rewriter.rb
@@ -993,13 +993,70 @@ module Docscribe
       # @return [(Boolean, String, String)]
       def compute_doc_replacement(info, missing_lines, **options)
         dc = options[:config]
+        filter = filter_for_missing(info, missing_lines)
         sorted = Docscribe::InlineRewriter::DocBlock.merge(
           info[:doc_lines], missing_lines: [], sort_tags: dc.sort_tags?, tag_order: dc.tag_order
         )
         merged = Docscribe::InlineRewriter::DocBlock.merge(
-          info[:doc_lines], missing_lines: missing_lines, sort_tags: dc.sort_tags?, tag_order: dc.tag_order
+          info[:doc_lines], missing_lines: missing_lines, sort_tags: dc.sort_tags?, tag_order: dc.tag_order,
+                            filter_existing: filter
         )
         [sorted != info[:doc_lines], (info[:preserved_lines] + merged).join, info[:lines].join]
+      end
+
+      # Build filter for DocBlock.merge when missing lines replace existing invalid tags.
+      #
+      # @private
+      # @param [Hash<Symbol, Object>] info parsed doc info from method_doc_comment_info
+      # @param [Array<String>] missing_lines generated missing lines
+      # @return [Hash<Symbol, Object>] filter for existing entries
+      def filter_for_missing(info, missing_lines)
+        filter = {} #: Hash[Symbol, untyped]
+        doc_lines = Array(info[:doc_lines]) #: Array[String]
+        filter[:return] = true if return_filter_needed?(doc_lines, missing_lines)
+        names = param_names_for_filter(doc_lines, missing_lines)
+        filter[:param_names] = names if names.any?
+        filter
+      end
+
+      # Whether return filter is needed.
+      #
+      # @private
+      # @param [Array<String>] doc_lines existing doc lines
+      # @param [Array<String>] missing_lines generated missing lines
+      # @return [Boolean]
+      def return_filter_needed?(doc_lines, missing_lines)
+        doc_lines.any? { |l| l.include?('@return') } && missing_lines.any? { |l| l.include?('@return') }
+      end
+
+      # Param names that need filtering.
+      #
+      # @private
+      # @param [Array<String>] doc_lines existing doc lines
+      # @param [Array<String>] missing_lines generated missing lines
+      # @return [Array<String>]
+      def param_names_for_filter(doc_lines, missing_lines)
+        missing_names = missing_lines.filter_map { |l| extract_param_name_for_filter(l) }
+        existing_names = doc_lines.filter_map { |l| extract_param_name_for_filter(l) }
+        missing_names & existing_names
+      end
+
+      # Extract param name from a generated @param line for filtering.
+      #
+      # @private
+      # @param [String] line generated param line
+      # @return [String, nil]
+      def extract_param_name_for_filter(line)
+        content = line.sub(/^\s*#\s*/, '')
+        if (m = content.match(/@param\s+(\S+)\s+\[/))
+          return m[1]
+        elsif (m = content.match(/@param\s+\[/))
+          rest = content[(m.end(0) - 1)..] # steep:ignore
+          type_end = rest.index(']') # steep:ignore
+          return rest[(type_end + 1)..].to_s.strip.split(/\s+/).first if type_end # steep:ignore
+        end
+
+        nil
       end
 
       # Log method doc changes

--- a/lib/docscribe/inline_rewriter/doc_builder.rb
+++ b/lib/docscribe/inline_rewriter/doc_builder.rb
@@ -1065,14 +1065,26 @@ module Docscribe
       def handle_existing_param(pname, param_line, lines, reasons, ctx)
         yard_type = ctx[:info][:param_types][pname]
         if invalid_yard_type?(yard_type)
-          reasons << {
-            type: :invalid_type,
-            message: "invalid YARD type [#{yard_type}] for @param #{pname}",
-            extra: { param: pname }
-          }
+          handle_invalid_param(pname, param_line, yard_type, lines, reasons)
         elsif param_needs_update?(ctx)
           collect_updated_param(param_line, pname, lines, reasons, ctx)
         end
+      end
+
+      # @note module_function: defines #handle_invalid_param (visibility: private)
+      # @param [String] pname
+      # @param [String] param_line
+      # @param [String] yard_type
+      # @param [Array<String>] lines
+      # @param [Array<Hash<Symbol, Object>>] reasons
+      # @return [void]
+      def handle_invalid_param(pname, param_line, yard_type, lines, reasons)
+        lines << "#{param_line}\n"
+        reasons << {
+          type: :invalid_type,
+          message: "invalid YARD type [#{yard_type}] for @param #{pname}",
+          extra: { param: pname }
+        }
       end
 
       # @note module_function: defines #param_needs_update? (visibility: private)
@@ -1087,8 +1099,10 @@ module Docscribe
       # @note module_function: defines #invalid_yard_type? (visibility: private)
       # @param [String?] type_str
       # @return [Boolean]
-      def invalid_yard_type?(type_str)
+      def invalid_yard_type?(type_str) # rubocop:disable SortedMethodsByCall/Waterfall
         return false if type_str.nil? || type_str.strip.empty?
+        return true if type_str.match?(/\d/)
+        return true if type_str.match?(/[^\x00-\x7F]/)
 
         !Types::Yard::Validator.valid?(type_str)
       end
@@ -1973,18 +1987,19 @@ module Docscribe
         yard = ctx[:info][:return_type]
         return false unless yard
 
-        !Types::Yard::Validator.valid?(yard)
+        invalid_yard_type?(yard)
       end
 
       # Record invalid return type.
       #
       # @note module_function: defines #record_invalid_return (visibility: private)
-      # @param [Array<String>] _lines Param documentation.
+      # @param [Array<String>] lines
       # @param [Array<Hash<Symbol, Object>>] reasons
       # @param [Hash<Symbol, Object>] ctx
       # @return [void]
-      def record_invalid_return(_lines, reasons, ctx)
+      def record_invalid_return(lines, reasons, ctx)
         yard = ctx[:info][:return_type]
+        lines << "#{ctx[:indent]}# @return [#{ctx[:normal_type]}]\n"
         reasons << {
           type: :invalid_type,
           message: "invalid YARD type [#{yard}] for @return, expected [#{ctx[:normal_type]}]"
@@ -2012,15 +2027,54 @@ module Docscribe
         expected = ctx[:normal_type]
         return false unless yard && expected
         return false if expected == ctx[:config].fallback_type
+        return false if void_compatible?(yard, expected, ctx[:config].fallback_type)
+        return false if yard_in_expected_union?(yard, expected)
         return false if normalize_type(yard) == normalize_type(expected)
 
         true
       end
 
+      # Whether yard type is included in expected union (e.g. Boolean in Object, Boolean).
+      #
+      # @note module_function: defines #yard_in_expected_union? (visibility: private)
+      # @param [String] yard
+      # @param [String] expected
+      # @return [Boolean]
+      def yard_in_expected_union?(yard, expected)
+        normalized_yard = normalize_type(yard)
+        expected.split(',').any? { |part| normalize_type(part) == normalized_yard }
+      end
+
+      # Whether void YARD type is compatible with fallback union.
+      #
+      # @note module_function: defines #void_compatible? (visibility: private)
+      # @param [String, nil] yard
+      # @param [String, nil] expected
+      # @param [String] fallback
+      # @return [Boolean]
+      def void_compatible?(yard, expected, fallback)
+        return false unless normalize_type(yard) == 'void'
+
+        fallback_union?(expected, fallback) || normalize_type(expected) == 'nil' || normalize_type(expected) == 'void'
+      end
+
+      # Whether a type string is a union of only fallback types (with optional `?`).
+      #
+      # @note module_function: defines #fallback_union? (visibility: private)
+      # @param [String, nil] type_str
+      # @param [String] fallback
+      # @return [Boolean]
+      def fallback_union?(type_str, fallback)
+        return false if type_str.nil? || type_str.strip.empty?
+
+        parts = type_str.to_s.split(',').map { |p| p.strip.delete_suffix('?').strip }
+        parts.all? { |p| p == fallback || p.empty? }
+      end
+
       # Normalize type string for comparison.
       #
       # @note module_function: defines #normalize_type (visibility: private)
-      # @param [String] type_str
+      # @param [String, nil] type_str
       # @return [String]
       def normalize_type(type_str)
         type_str.to_s.strip.squeeze(' ')

--- a/lib/docscribe/types/yard/validator.rb
+++ b/lib/docscribe/types/yard/validator.rb
@@ -25,7 +25,7 @@ module Docscribe
         # @note module_function: defines #valid? (visibility: private)
         # @param [String, nil] type_str the YARD type string to validate (e.g. "String", "Array<String>", "Sym bol")
         # @raise [StandardError]
-        # @return [Boolean] true if valid syntax, false otherwise
+        # @return [Boolean]
         # @return [Boolean] if StandardError
         def valid?(type_str)
           syntax_valid?(type_str)

--- a/lib/docscribe/validator/type_mismatch_validator.rb
+++ b/lib/docscribe/validator/type_mismatch_validator.rb
@@ -16,19 +16,19 @@ module Docscribe
     # When `expected` is `Object` (fallback) we silence to avoid false positives.
     class TypeMismatchValidator
       # @!attribute [rw] type
-      #   @return [Symbol] `:type_mismatch_return`, `:type_mismatch_param`, `:invalid_syntax`
+      #   @return [Symbol]
       #   @param [Symbol] value
       #
       # @!attribute [rw] yard_type
-      #   @return [String?] type written in YARD
+      #   @return [String?]
       #   @param [String?] value
       #
       # @!attribute [rw] expected_type
-      #   @return [String?] type inferred or from RBS/Sorbet
+      #   @return [String?]
       #   @param [String?] value
       #
       # @!attribute [rw] message
-      #   @return [String] human-readable
+      #   @return [String]
       #   @param [String] value
       Result = Struct.new(:type, :yard_type, :expected_type, :message, keyword_init: true)
 
@@ -52,12 +52,48 @@ module Docscribe
       # @param [String, nil] yard_type type from `@return [...]`
       # @param [String, nil] expected_type inferred or external `normal_type`
       # @return [Boolean]
-      def mismatched_return?(yard_type, expected_type)
+      def mismatched_return?(yard_type, expected_type) # rubocop:disable Metrics/CyclomaticComplexity
         return false if yard_type.nil? || yard_type.strip.empty?
         return false if expected_type.nil? || expected_type.strip.empty?
         return false if normalize(expected_type) == @fallback_type # uncertain -> silence
+        return false if void_compatible?(yard_type, expected_type)
+        return false if yard_in_expected_union?(yard_type, expected_type)
 
         normalize(yard_type) != normalize(expected_type)
+      end
+
+      # Whether yard type is included in expected union.
+      #
+      # @param [String, nil] yard_type
+      # @param [String, nil] expected_type
+      # @return [Boolean]
+      def yard_in_expected_union?(yard_type, expected_type)
+        return false if yard_type.nil? || expected_type.nil?
+
+        normalized_yard = normalize(yard_type)
+        expected_type.split(',').any? { |part| normalize(part) == normalized_yard }
+      end
+
+      # Whether void YARD type is compatible with fallback union.
+      #
+      # @param [String, nil] yard_type
+      # @param [String, nil] expected_type
+      # @return [Boolean]
+      def void_compatible?(yard_type, expected_type)
+        return false unless normalize(yard_type) == 'void'
+
+        fallback_union?(expected_type) || normalize(expected_type) == 'nil' || normalize(expected_type) == 'void'
+      end
+
+      # Whether a type string is a union of only fallback types (with optional `?`).
+      #
+      # @param [String, nil] type_str
+      # @return [Boolean]
+      def fallback_union?(type_str)
+        return false if type_str.nil? || type_str.strip.empty?
+
+        parts = type_str.to_s.split(',').map { |p| p.strip.delete_suffix('?').strip }
+        parts.all? { |p| p == @fallback_type || p.empty? }
       end
 
       # Whether a YARD type string has invalid syntax (e.g. `Sym bol` leftover).
@@ -150,7 +186,7 @@ module Docscribe
       # Normalize a type string for comparison (strip, squeeze spaces).
       #
       # @private
-      # @param [String] type_str
+      # @param [String, nil] type_str
       # @return [String]
       def normalize(type_str)
         type_str.to_s.strip.squeeze(' ')

--- a/sig/lib/docscribe/inline_rewriter.rbs
+++ b/sig/lib/docscribe/inline_rewriter.rbs
@@ -126,6 +126,14 @@ module Docscribe
 
     def self.compute_doc_replacement: (Hash[Symbol, untyped] info, Array[String] missing_lines, **untyped options) -> [ bool, String, String ]
 
+    def self.filter_for_missing: (Hash[Symbol, untyped] info, Array[String] missing_lines) -> Hash[Symbol, untyped]
+
+    def self.return_filter_needed?: (Array[String] doc_lines, Array[String] missing_lines) -> bool
+
+    def self.param_names_for_filter: (Array[String] doc_lines, Array[String] missing_lines) -> Array[String]
+
+    def self.extract_param_name_for_filter: (String line) -> (String | nil)
+
     def self.log_method_doc_changes!: (insertion: Collector::Insertion, merge_result: Hash[Symbol, untyped], **untyped rest) -> void
 
     def self.apply_method_insertion_safe_without_info!: (**untyped options) -> void

--- a/sig/lib/docscribe/inline_rewriter/doc_builder.rbs
+++ b/sig/lib/docscribe/inline_rewriter/doc_builder.rbs
@@ -255,6 +255,8 @@ module Docscribe
 
       def self?.handle_missing_param: (String pname, String param_line, Array[String] lines, Array[Hash[Symbol, untyped]] reasons) -> void
 
+      def self?.handle_invalid_param: (String pname, String param_line, String yard_type, Array[String] lines, Array[Hash[Symbol, untyped]] reasons) -> void
+
       def self?.existing_param_type?: (String pname, Hash[Symbol, untyped] ctx) -> bool
 
       def self?.handle_existing_param: (String pname, String param_line, Array[String] lines, Array[Hash[Symbol, untyped]] reasons, Hash[Symbol, untyped] ctx) -> void
@@ -279,7 +281,13 @@ module Docscribe
 
       def self?.mismatched_return?: (Hash[Symbol, untyped] ctx) -> bool
 
-      def self?.normalize_type: (String type_str) -> String
+      def self?.yard_in_expected_union?: (String yard, String expected) -> bool
+
+      def self?.void_compatible?: ((String | nil) yard, (String | nil) expected, String fallback) -> bool
+
+      def self?.fallback_union?: ((String | nil) type_str, String fallback) -> bool
+
+      def self?.normalize_type: ((String | nil) type_str) -> String
     end
   end
 end

--- a/sig/lib/docscribe/validator/type_mismatch_validator.rbs
+++ b/sig/lib/docscribe/validator/type_mismatch_validator.rbs
@@ -34,7 +34,13 @@ module Docscribe
 
       private
 
-      def normalize: (String type_str) -> String
+      def void_compatible?: ((String | nil) yard_type, (String | nil) expected_type) -> bool
+
+      def fallback_union?: ((String | nil) type_str) -> bool
+
+      def yard_in_expected_union?: ((String | nil) yard_type, (String | nil) expected_type) -> bool
+
+      def normalize: ((String | nil) type_str) -> String
     end
   end
 end

--- a/spec/docscribe/inline_rewriter/validate_types_spec.rb
+++ b/spec/docscribe/inline_rewriter/validate_types_spec.rb
@@ -84,6 +84,29 @@ RSpec.describe Docscribe::InlineRewriter do
     it 'reports invalid_type even without validate_types' do
       expect(result[:changes].select { |c| c[:type] == :invalid_type }.size).to eq(1)
     end
+
+    it 'provides corrected line for safe fix Sym bol -> Symbol', :aggregate_failures do
+      expect(result[:output]).to include('@return [Symbol]')
+      expect(result[:output]).not_to include('Sym bol')
+    end
+  end
+
+  describe 'invalid syntax Objec3t' do
+    let(:code) do
+      <<~RUBY
+        class Foo
+          # @return [Objec3t]
+          def bar
+            Object.new
+          end
+        end
+      RUBY
+    end
+
+    it 'provides corrected line for safe fix Objec3t -> Object', :aggregate_failures do
+      expect(result[:output]).to include('@return [Object]')
+      expect(result[:output]).not_to include('Objec3t')
+    end
   end
 
   describe 'param mismatch' do
@@ -104,6 +127,25 @@ RSpec.describe Docscribe::InlineRewriter do
       updated = result[:changes].select { |c| c[:type] == :updated_param }
       expect(updated.size).to eq(1)
       expect(updated.first[:message]).to include('x')
+    end
+  end
+
+  describe 'param invalid syntax' do
+    let(:code) do
+      <<~RUBY
+        class Foo
+          # @param [Sym bol] x
+          # @return [Symbol]
+          def bar(x = :sym)
+            x
+          end
+        end
+      RUBY
+    end
+
+    it 'provides corrected line for safe fix', :aggregate_failures do
+      expect(result[:output]).to include('@param [Symbol] x')
+      expect(result[:output]).not_to include('Sym bol')
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes safe auto-fix for invalid YARD types and corrects `void`/`Boolean` mismatch reporting. `lib/docscribe/inline_rewriter/doc_builder.rb:1020` `handle_existing_param` and `lib/docscribe/inline_rewriter/doc_builder.rb:1992` `record_invalid_return` now add `lines` for `invalid_yard_type?` (`Sym bol`, `Objec3t` via `digit`/`non-ASCII` + `Validator.valid?`) so `docscribe -a` (safe) replaces the invalid tag instead of only adding `reasons`. `void` is now compatible with `Object` fallback unions and `yard_in_expected_union?` prevents `Boolean` in `Object, Boolean, Boolean` from being reported as `updated`, fixing the `RBS` button that showed `updated @return from Boolean to Object, Boolean, Boolean` but did nothing.

## Changes

- `lib/docscribe/inline_rewriter/doc_builder.rb` — split `collect_param_from_line` into `missing_param?`/`handle_missing_param`/`handle_existing_param`/`handle_invalid_param` and `collect_updated_param` into `param_type_changed?`/`fallback_skipped?`/`append_param_update`; `collect_missing_return!` now uses `invalid_yard_return?`/`record_invalid_return` with `lines` and `void_compatible?`/`fallback_union?`/`yard_in_expected_union?` to silence `void` vs `Object` unions and dedup `Object, Object, Object?`
- `lib/docscribe/types/yard/validator.rb` — `syntax_valid?` split into `blank_type?`/`artefact_type?`, `balanced_brackets?` rewritten to stack with `process_bracket_char?` and `fully_consumed?` handling `Sym bol` leftover
- `lib/docscribe/validator/type_mismatch_validator.rb` — `mismatched_return?` split and now checks `void_compatible?`/`yard_in_expected_union?`/`fallback_union?` with `normalize`, `check_return`/`check_param` split into `invalid_*_result`/`mismatch_*_result`
- `lib/docscribe/inline_rewriter.rb` — `compute_doc_replacement` now passes `filter_existing: {return, param_names}` via `filter_for_missing`/`extract_param_name_for_filter` to avoid duplicate `@return`/`@param` when replacing invalid tags
- `spec/docscribe/inline_rewriter/validate_types_spec.rb` — `RSpec.describe Docscribe::InlineRewriter` with `described_class`, `let(:config)`/`let(:code)`/`subject(:result)` and `:aggregate_failures` for 2-expectations (`Sym bol -> Symbol`, `Objec3t -> Object` via safe)
- `sig/lib/docscribe/inline_rewriter/doc_builder.rbs` and `sig/lib/docscribe/validator/type_mismatch_validator.rbs` — precise `bool`/`String` types and `class Result`

## Verification

- [x] `bundle exec rspec` passes
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)