### PR TITLE
[1.6.2] Fix config command and status check

### DIFF
--- a/exe/docscribe-client
+++ b/exe/docscribe-client
@@ -156,8 +156,12 @@ when :ping
   puts JSON.generate(result || { error: 'Connection failed' })
 when :status
   alive = begin
-    File.exist?(sock) &&
-      UNIXSocket.new(sock).close && true
+    if File.exist?(sock)
+      UNIXSocket.new(sock).close
+      true
+    else
+      false
+    end
   rescue StandardError
     false
   end

--- a/lib/docscribe/cli.rb
+++ b/lib/docscribe/cli.rb
@@ -6,6 +6,24 @@ require 'docscribe/cli/run'
 module Docscribe
   # CLI entry point and command dispatch.
   module CLI
+    COMMANDS = {
+      'check_for_comments' => :CheckForComments,
+      'config' => :ConfigDump,
+      'coverage' => :Coverage,
+      'generate' => :Generate,
+      'init' => :Init,
+      'rbs' => :RbsGen,
+      'server' => :ServerCmd,
+      'sigs' => :Sigs,
+      'update_types' => :UpdateTypes
+    }.freeze
+
+    # Subcommands whose file name differs from the command name.
+    SUBCOMMAND_FILES = {
+      'config' => 'config_dump',
+      'rbs' => 'rbs_gen'
+    }.freeze
+
     class << self
       # @param [Array<String>] argv
       # @return [Integer]
@@ -16,18 +34,6 @@ module Docscribe
         options = Docscribe::CLI::Options.parse!(argv)
         Docscribe::CLI::Run.run(options: options, argv: argv)
       end
-
-      COMMANDS = {
-        'check_for_comments' => :CheckForComments,
-        'config' => :ConfigDump,
-        'coverage' => :Coverage,
-        'generate' => :Generate,
-        'init' => :Init,
-        'rbs' => :RbsGen,
-        'server' => :ServerCmd,
-        'sigs' => :Sigs,
-        'update_types' => :UpdateTypes
-      }.freeze
 
       private
 
@@ -46,7 +52,7 @@ module Docscribe
         const_name = COMMANDS[cmd]
         return 0 unless const_name
 
-        require "docscribe/cli/#{cmd == 'rbs' ? 'rbs_gen' : cmd}"
+        require "docscribe/cli/#{SUBCOMMAND_FILES.fetch(cmd) { cmd }}"
         Docscribe::CLI.const_get(const_name).run(argv)
       end
     end

--- a/sig/lib/docscribe/cli.rbs
+++ b/sig/lib/docscribe/cli.rbs
@@ -6,6 +6,8 @@ module Docscribe
 
     COMMANDS: Hash[String, Symbol]
 
+    SUBCOMMAND_FILES: Hash[String, String]
+
     def self.run: (Array[String] argv) -> Integer
 
     private

--- a/spec/docscribe/cli/dispatch_spec.rb
+++ b/spec/docscribe/cli/dispatch_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'tmpdir'
+require 'docscribe/cli'
+
+RSpec.describe Docscribe::CLI do
+  describe '.dispatch_subcommand' do
+    it 'maps every COMMANDS entry to a loadable file defining its constant' do
+      described_class::COMMANDS.each do |cmd, const_name|
+        file = described_class::SUBCOMMAND_FILES.fetch(cmd, cmd)
+        expect { require "docscribe/cli/#{file}" }.not_to raise_error
+        expect(described_class.const_get(const_name)).not_to be_nil
+      end
+    end
+
+    it 'runs config --help without LoadError' do
+      Dir.mktmpdir do |dir|
+        _out, status = Open3.capture2('ruby', exe, 'config', '--help', chdir: dir)
+        expect(status.exitstatus).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/docscribe/server/client_status_spec.rb
+++ b/spec/docscribe/server/client_status_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+# rubocop:disable RSpec/DescribeClass -- tests the exe script, not a class
+RSpec.describe 'docscribe-client --status' do
+  subject(:reported_status) { JSON.parse(client_output)['status'] }
+
+  let(:client_exe) { File.expand_path('../../../exe/docscribe-client', __dir__) }
+  let(:workdir) { Dir.mktmpdir }
+  let(:client_output) do
+    out, _status = Open3.capture2('ruby', client_exe, '--status', chdir: workdir)
+    out
+  end
+  let(:socket_path) do
+    out, _status = Open3.capture2('ruby', client_exe, '--socket-path', chdir: workdir)
+    out.strip
+  end
+
+  after { FileUtils.rm_rf(workdir) }
+
+  it 'reports not_running when no daemon listens' do
+    expect(reported_status).to eq('not_running')
+  end
+
+  context 'with a server accepting on the socket' do
+    subject(:reported_status) do
+      with_dummy_server(socket_path) { JSON.parse(client_output)['status'] }
+    end
+
+    it 'reports running' do
+      expect(reported_status).to eq('running')
+    end
+  end
+
+  context 'with a stale socket file' do
+    subject(:reported_status) do
+      with_dummy_server(socket_path) { nil }
+      JSON.parse(client_output)['status']
+    end
+
+    it 'reports not_running' do
+      expect(reported_status).to eq('not_running')
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   config.include CollectionLoaderHelper
   config.include KeepDescriptionsHelper
   config.include NormalizeCommentHelper
+  config.include DummyServerHelper
   config.example_status_persistence_file_path = '.rspec_status'
   config.disable_monkey_patching!
   config.expect_with(:rspec) { |c| c.syntax = :expect }

--- a/spec/support/dummy_server_helper.rb
+++ b/spec/support/dummy_server_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'socket'
+
+module DummyServerHelper
+  # Method documentation.
+  #
+  # @param [Object] sock Param documentation.
+  # @return [Object]
+  def with_dummy_server(sock)
+    server = UNIXServer.new(sock)
+    thread = Thread.new { drain_server(server) }
+    yield
+  ensure
+    server.close
+    thread.kill
+    thread.join(5)
+  end
+
+  private
+
+  # Method documentation.
+  #
+  # @private
+  # @param [Object] server Param documentation.
+  # @raise [IOError]
+  # @raise [Errno::EBADF]
+  # @return [Object]
+  # @return [nil] if IOError, Errno::EBADF
+  def drain_server(server)
+    loop do
+      client = server.accept
+      client&.close
+    end
+  rescue IOError, Errno::EBADF
+    nil
+  end
+end


### PR DESCRIPTION
## Summary

Fixes two small but user-visible CLI bugs: `docscribe config` crashed with `LoadError` because the dispatcher derived the file name from the command name (`config` -> `config.rb`, which doesn't exist), and `docscribe-client --status` always reported `not_running` because `UNIXSocket#close` returns `nil`, making the liveness expression falsy even against a live daemon.

## Changes

- `lib/docscribe/cli.rb`: added an explicit `SUBCOMMAND_FILES` map (`config -> config_dump`, `rbs -> rbs_gen`) used by `dispatch_subcommand`; moved `COMMANDS`/`SUBCOMMAND_FILES` to module level so they are addressable as `Docscribe::CLI::COMMANDS`.
- `sig/lib/docscribe/cli.rbs`: declared `SUBCOMMAND_FILES`.
- `exe/docscribe-client`: `--status` now returns `true` only after a successful socket connect; missing socket file and connection errors still report `not_running` (including the stale-socket case).
- `spec/docscribe/cli/dispatch_spec.rb` (new): every `COMMANDS` entry resolves to a loadable file defining its constant, plus a `config --help` regression test.
- `spec/docscribe/server/client_status_spec.rb` (new): `--status` against no daemon, a live dummy server, and a stale socket file — `subject`/`let`-only, no helper methods in the file.
- `spec/support/dummy_server_helper.rb` (new): shared `DummyServerHelper#with_dummy_server`, wired into `spec_helper.rb`.

## Verification

- [x] `bundle exec rspec` passes (new specs 5/5; related `config_dump`, `client`, `cli` specs 18/18)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)