### PR TITLE
[1.6.2] Fix config overrides and collection warning

### DIFF
--- a/lib/docscribe/cli/config_builder.rb
+++ b/lib/docscribe/cli/config_builder.rb
@@ -22,7 +22,7 @@ module Docscribe
       # @param [Hash<Symbol, Object>] options parsed CLI options
       # @return [Docscribe::Config] merged effective config
       def build(base, options)
-        return base unless needs_override?(options)
+        return warn_and_return_base(base, options) unless needs_override?(options)
 
         raw = Marshal.load(Marshal.dump(base.raw))
         apply_filter_overrides(raw, options)
@@ -46,6 +46,19 @@ module Docscribe
           sorbet_overrides?(options) ||
           output_overrides?(options) ||
           validation_overrides?(options)
+      end
+
+      # Warn about a missing collection opt-in and return the base config unchanged.
+      #
+      # Used when no CLI override is present so the nudge still fires on plain runs.
+      #
+      # @note module_function: defines #warn_and_return_base (visibility: private)
+      # @param [Docscribe::Config] base base config loaded from YAML/defaults
+      # @param [Hash<Symbol, Object>] options parsed CLI options
+      # @return [Docscribe::Config] base config unchanged
+      def warn_and_return_base(base, options)
+        warn_missing_rbs_collection(base, options)
+        base
       end
 
       # Whether any method or file filter CLI options were provided.
@@ -203,7 +216,7 @@ module Docscribe
       # @param [Hash<Symbol, Object>] options parsed CLI options
       # @return [Boolean]
       def validation_overrides?(options)
-        !!options[:validate_types]
+        !options[:validate_types].nil?
       end
 
       # Apply validation-related CLI overrides to the raw config.
@@ -213,7 +226,7 @@ module Docscribe
       # @param [Hash<Symbol, Object>] options parsed CLI options
       # @return [void]
       def apply_validation_overrides(raw, options)
-        raw['validate_types'] = true if options[:validate_types]
+        raw['validate_types'] = options[:validate_types]
       end
 
       # Warn when rbs_collection.lock.yaml exists but --rbs-collection was not passed.

--- a/lib/docscribe/cli/options.rb
+++ b/lib/docscribe/cli/options.rb
@@ -29,7 +29,7 @@ module Docscribe
         progress: false,
         parallel: false,
         server: false,
-        validate_types: false
+        validate_types: nil #: true or false when --[no-]validate-types is passed, nil otherwise
       }.freeze
 
       module_function

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -770,8 +770,10 @@ module Docscribe
         # @param [Docscribe::CLI::Run::run_ctx] ctx
         # @return [Boolean]
         def validate_types_enabled?(ctx)
-          ctx[:options][:validate_types] ||
-            (ctx[:conf].respond_to?(:validate_types?) && ctx[:conf].validate_types?)
+          return true if ctx[:options][:validate_types] == true
+          return false if ctx[:options][:validate_types] == false
+
+          ctx[:conf].respond_to?(:validate_types?) && ctx[:conf].validate_types?
         end
 
         # @private

--- a/lib/docscribe/cli/update_types.rb
+++ b/lib/docscribe/cli/update_types.rb
@@ -97,7 +97,7 @@ module Docscribe
           has_collection = File.exist?(File.join(dir_for_flag, 'rbs_collection.lock.yaml')) || File.exist?('rbs_collection.lock.yaml')
           flag = has_collection ? '--rbs-collection' : '--rbs'
           extra = @extra_argv || []
-          filtered = extra.reject { |a| %w[--no-rbs --no-validate-types].include?(a) }
+          filtered = extra.reject { |a| a == '--no-rbs' }
           has_rbs_flag = extra.any? { |a| %w[--rbs --rbs-collection --no-rbs].include?(a) }
           has_no_rbs = extra.include?('--no-rbs')
           argv1 = ['-AkB']
@@ -120,7 +120,7 @@ module Docscribe
           has_collection = File.exist?(File.join(dir_for_flag, 'rbs_collection.lock.yaml')) || File.exist?('rbs_collection.lock.yaml')
           flag = has_collection ? '--rbs-collection' : '--rbs'
           extra = @extra_argv || []
-          filtered = extra.reject { |a| %w[--no-rbs --no-validate-types].include?(a) }
+          filtered = extra.reject { |a| a == '--no-rbs' }
           has_rbs_flag = extra.any? { |a| %w[--rbs --rbs-collection --no-rbs].include?(a) }
           has_no_rbs = extra.include?('--no-rbs')
           argv2 = ['-aB']

--- a/sig/lib/docscribe/cli/config_builder.rbs
+++ b/sig/lib/docscribe/cli/config_builder.rbs
@@ -3,6 +3,8 @@ module Docscribe
     module ConfigBuilder
       def self?.build: (Config base, Hash[Symbol, untyped] options) -> Config
 
+      def self?.warn_and_return_base: (Config base, Hash[Symbol, untyped] options) -> Config
+
       def self?.needs_override?: (Hash[Symbol, untyped] options) -> bool
 
       def self?.filter_overrides?: (Hash[Symbol, untyped] options) -> bool

--- a/sig/lib/docscribe/cli/options.rbs
+++ b/sig/lib/docscribe/cli/options.rbs
@@ -1,7 +1,7 @@
 module Docscribe
   module CLI
     module Options
-      DEFAULT: { stdin: false, mode: :check, strategy: :safe, verbose: false, explain: false, quiet: false, format: :text, config: nil, include: Array[String], exclude: Array[String], include_file: Array[String], exclude_file: Array[String], rbs: false, sig_dirs: Array[String], sorbet: false, rbi_dirs: Array[String], rbs_collection: false, keep_descriptions: false, no_boilerplate: false, progress: false, parallel: false, server: false, validate_types: false }
+      DEFAULT: { stdin: false, mode: :check, strategy: :safe, verbose: false, explain: false, quiet: false, format: :text, config: nil, include: Array[String], exclude: Array[String], include_file: Array[String], exclude_file: Array[String], rbs: false, sig_dirs: Array[String], sorbet: false, rbi_dirs: Array[String], rbs_collection: false, keep_descriptions: false, no_boilerplate: false, progress: false, parallel: false, server: false, validate_types: nil }
 
       BANNER: String
 

--- a/spec/docscribe/cli/config_builder_spec.rb
+++ b/spec/docscribe/cli/config_builder_spec.rb
@@ -148,4 +148,89 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
       end
     end
   end
+
+  describe 'validation_overrides?' do
+    it 'returns false when the flag was not passed (nil default)' do
+      expect(described_class.validation_overrides?(default_options)).to be(false)
+    end
+
+    it 'returns true for explicit --validate-types' do
+      opts = default_options.merge(validate_types: true)
+      expect(described_class.validation_overrides?(opts)).to be(true)
+    end
+
+    it 'returns true for explicit --no-validate-types' do
+      opts = default_options.merge(validate_types: false)
+      expect(described_class.validation_overrides?(opts)).to be(true)
+    end
+  end
+
+  describe 'apply_validation_overrides' do
+    it 'sets true for --validate-types' do
+      raw = {}
+      described_class.apply_validation_overrides(raw, default_options.merge(validate_types: true))
+      expect(raw['validate_types']).to be(true)
+    end
+
+    it 'sets false for --no-validate-types' do
+      raw = { 'validate_types' => true }
+      described_class.apply_validation_overrides(raw, default_options.merge(validate_types: false))
+      expect(raw['validate_types']).to be(false)
+    end
+  end
+
+  describe 'build with validate_types' do
+    it 'keeps yml true when the flag was not passed', :aggregate_failures do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(false)
+      base = Docscribe::Config.new('validate_types' => true)
+      expect(described_class.build(base, default_options).validate_types?).to be(true)
+    end
+
+    it 'lets explicit false override yml true' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(false)
+      base = Docscribe::Config.new('validate_types' => true)
+      opts = default_options.merge(validate_types: false)
+      expect(described_class.build(base, opts).validate_types?).to be(false)
+    end
+
+    it 'lets explicit true enable validation without yml' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(false)
+      base = Docscribe::Config.new
+      opts = default_options.merge(validate_types: true)
+      expect(described_class.build(base, opts).validate_types?).to be(true)
+    end
+  end
+
+  describe 'build without overrides warns about missing collection' do
+    let(:base) { Docscribe::Config.new }
+
+    it 'warns when the lock file exists' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(true)
+      expect { described_class.build(base, default_options) }
+        .to output(/rbs_collection\.lock\.yaml found but --rbs-collection not set/).to_stderr
+    end
+
+    it 'returns the base config object' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(true)
+      expect(described_class.build(base, default_options)).to be(base)
+    end
+
+    it 'stays silent without the lock file' do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(false)
+      expect { described_class.build(base, default_options) }.not_to output.to_stderr
+    end
+
+    it 'stays silent when suppression is configured' do
+      base = Docscribe::Config.new('rbs' => { 'warn_missing_collection' => false })
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(true)
+      expect { described_class.build(base, default_options) }.not_to output.to_stderr
+    end
+  end
 end

--- a/spec/docscribe/cli/options_spec.rb
+++ b/spec/docscribe/cli/options_spec.rb
@@ -160,9 +160,9 @@ RSpec.describe Docscribe::CLI::Options do
     expect(opts[:rbs]).to be(false)
   end
 
-  it 'defaults validate_types to false' do
+  it 'defaults validate_types to nil (flag not passed)' do
     opts = described_class.parse!(%w[lib])
-    expect(opts[:validate_types]).to be(false)
+    expect(opts[:validate_types]).to be_nil
   end
 
   it 'last flag wins for repeated validate-types', :aggregate_failures do

--- a/spec/docscribe/cli/update_types_validate_types_spec.rb
+++ b/spec/docscribe/cli/update_types_validate_types_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe Docscribe::CLI::UpdateTypes do
         described_class.send(:run_first_pass, tmp_dir)
       end
 
-      it 'filters --no-validate-types from Options.parse!', :aggregate_failures do
-        expect(captured_argv).not_to include('--no-validate-types')
+      it 'forwards --no-validate-types to Options.parse!', :aggregate_failures do
+        expect(captured_argv).to include('--no-validate-types')
         expect(captured_argv).not_to include('--validate-types')
       end
 
@@ -145,8 +145,8 @@ RSpec.describe Docscribe::CLI::UpdateTypes do
         expect(captured_argv.count(tmp_dir)).to eq(1)
       end
 
-      it 'does not include --no-validate-types in any position' do
-        expect(captured_argv.grep(/validate-types/)).to be_empty
+      it 'forwards exactly one --no-validate-types' do
+        expect(captured_argv.grep(/--no-validate-types/).count).to eq(1)
       end
     end
 
@@ -175,9 +175,9 @@ RSpec.describe Docscribe::CLI::UpdateTypes do
         described_class.send(:run_first_pass, tmp_dir)
       end
 
-      it 'filters both negated flags', :aggregate_failures do
+      it 'filters --no-rbs but forwards --no-validate-types', :aggregate_failures do
         expect(captured_argv).not_to include('--no-rbs')
-        expect(captured_argv).not_to include('--no-validate-types')
+        expect(captured_argv).to include('--no-validate-types')
         expect(captured_argv).not_to include(tmp_dir)
       end
     end
@@ -317,9 +317,9 @@ RSpec.describe Docscribe::CLI::UpdateTypes do
         described_class.send(:run_second_pass, tmp_dir)
       end
 
-      it 'filters --no-validate-types', :aggregate_failures do
-        expect(captured_argv).not_to include('--no-validate-types')
-        expect(captured_argv.grep(/validate-types/)).to be_empty
+      it 'forwards --no-validate-types to the safe pass', :aggregate_failures do
+        expect(captured_argv).to include('--no-validate-types')
+        expect(captured_argv).not_to include('--validate-types')
         expect(captured_argv.count(tmp_dir)).to eq(1)
       end
     end
@@ -441,9 +441,9 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
       expect(described_class.validation_overrides?(default_options)).to be(false)
     end
 
-    it 'returns false when validate_types false' do
+    it 'returns true when validate_types false (explicit negation)' do
       opts = default_options.merge(validate_types: false)
-      expect(described_class.validation_overrides?(opts)).to be(false)
+      expect(described_class.validation_overrides?(opts)).to be(true)
     end
 
     it 'returns true when validate_types true' do
@@ -465,15 +465,15 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
       expect(raw['validate_types']).to be(true)
     end
 
-    it 'does not set validate_types when false' do
+    it 'sets validate_types false when false' do
       described_class.apply_validation_overrides(raw, default_options.merge(validate_types: false))
-      expect(raw).not_to have_key('validate_types')
+      expect(raw['validate_types']).to be(false)
     end
 
-    it 'does not overwrite when false and raw already true', :aggregate_failures do
+    it 'overwrites raw true when false (explicit negation wins)', :aggregate_failures do
       raw['validate_types'] = true
       described_class.apply_validation_overrides(raw, default_options.merge(validate_types: false))
-      expect(raw['validate_types']).to be(true)
+      expect(raw['validate_types']).to be(false)
     end
 
     it 'preserves other raw keys', :aggregate_failures do
@@ -490,9 +490,9 @@ RSpec.describe Docscribe::CLI::ConfigBuilder do
       expect(described_class.needs_override?(opts)).to be(true)
     end
 
-    it 'returns false when validate_types false' do
+    it 'returns true when validate_types false (explicit negation counts)' do
       opts = default_options.merge(validate_types: false)
-      expect(described_class.needs_override?(opts)).to be(false)
+      expect(described_class.needs_override?(opts)).to be(true)
     end
   end
 
@@ -546,9 +546,9 @@ RSpec.describe Docscribe::CLI::Options do
   end
 
   describe '.parse! validate_types' do
-    it 'defaults validate_types to false' do
+    it 'defaults validate_types to nil (flag not passed)' do
       opts = described_class.parse!(%w[lib])
-      expect(opts[:validate_types]).to be(false)
+      expect(opts[:validate_types]).to be_nil
     end
 
     it 'sets true for --validate-types' do

--- a/spec/docscribe/server/daemon_spec.rb
+++ b/spec/docscribe/server/daemon_spec.rb
@@ -430,6 +430,27 @@ RSpec.describe Docscribe::Server::Daemon do
       end
     end
 
+    describe 'missing collection warning with empty overrides' do
+      it 'warns when the lock file exists even without cli_overrides' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.instance_variable_set(:@config, Docscribe::Config.new)
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(true)
+          expect { daemon.send(:build_effective_config, {}) }
+            .to output(/rbs_collection\.lock\.yaml found but --rbs-collection not set/).to_stderr
+        end
+      end
+
+      it 'stays silent without the lock file' do
+        with_cache_dir do |daemon, _test_file|
+          daemon.instance_variable_set(:@config, Docscribe::Config.new)
+          allow(File).to receive(:exist?).and_call_original
+          allow(File).to receive(:exist?).with('rbs_collection.lock.yaml').and_return(false)
+          expect { daemon.send(:build_effective_config, {}) }.not_to output.to_stderr
+        end
+      end
+    end
+
     describe 'REQUEST_HANDLERS dispatch' do
       let(:tmp_dir) { Dir.mktmpdir }
       let(:dispatch_daemon) { described_class.new(socket_path: "#{tmp_dir}/dispatch.sock", idle_timeout: 60) }


### PR DESCRIPTION
## Summary

Makes CLI flag overrides behave predictably in two places: the missing-collection nudge now fires on plain runs instead of only when other flags are passed, and explicit `--[no-]validate-types` is distinguished from "flag not passed", so `--no-validate-types` actually disables a `validate_types: true` from `docscribe.yml` (previously the negation was silently dropped). `update_types` forwards the negation to both passes.

## Changes

- `lib/docscribe/cli/config_builder.rb`: `build` evaluates the missing-collection warning even with empty options (new `warn_and_return_base` helper); `validation_overrides?`/`apply_validation_overrides` key off `nil` vs explicit `true`/`false` instead of truthiness.
- `lib/docscribe/cli/options.rb`: `validate_types` default changed `false` -> `nil` (means "not passed"); it is the only `--[no-]` boolean in the CLI, other flags are positive-only and unaffected.
- `lib/docscribe/cli/run.rb`: `validate_types_enabled?` gives an explicit CLI value precedence, falling back to config otherwise.
- `lib/docscribe/cli/update_types.rb`: `--no-validate-types` is no longer filtered out of pass argvs (`--no-rbs` still is — the main parser cannot parse it).
- `sig/.../config_builder.rbs`, `sig/.../options.rbs`: signatures updated.
- Specs: new `validation_overrides?`/`apply_validation_overrides`/build/warning cases in `config_builder_spec.rb`, daemon empty-overrides warning cases in `daemon_spec.rb`; updated expectations encoding the old behavior in `options_spec.rb` and `update_types_validate_types_spec.rb`.

## Verification

- [x] `bundle exec rspec` passes (345/345 in the affected suites)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)