### PR TITLE
[1.6.2] Add type field and merge duplicate files

### DIFF
--- a/lib/docscribe/cli/formatters/json.rb
+++ b/lib/docscribe/cli/formatters/json.rb
@@ -130,11 +130,12 @@ module Docscribe
         # @return [void]
         def append_check_files(state, files)
           state[:fail_paths].each do |path|
-            files << file_entry(path, state[:fail_changes][path] || [])
+            merge_or_append(files, path, build_offenses(state[:fail_changes][path] || []))
           end
 
           state[:type_mismatch_paths].each do |path|
-            files << file_entry(path, state[:type_mismatch_changes][path] || [], severity: 'warning')
+            changes = state[:type_mismatch_changes][path] || []
+            merge_or_append(files, path, build_offenses(changes, severity: 'warning'))
           end
         end
 
@@ -170,7 +171,7 @@ module Docscribe
         # @param [Array<Docscribe::CLI::Formatters::Json::json_offense>] offenses offense objects array
         # @return [void]
         def merge_or_append(files, path, offenses)
-          existing = files.find { |f| f[:path] == path }
+          existing = files.find { |f| normalize_path(f[:path]) == normalize_path(path) }
 
           if existing
             existing[:offenses].concat(offenses)
@@ -179,15 +180,18 @@ module Docscribe
           end
         end
 
-        # Build single file entry hash.
+        # Normalize a path for dedup comparison, resolving symlinks
+        # (e.g. /tmp vs /private/tmp on macOS).
         #
         # @private
         # @param [String] path file path string
-        # @param [Array<Docscribe::CLI::Formatters::change>] changes changes info array
-        # @param [String?] severity offense severity level
-        # @return [Docscribe::CLI::Formatters::Json::json_file]
-        def file_entry(path, changes, severity: nil)
-          { path: path, offenses: build_offenses(changes, severity: severity) }
+        # @raise [SystemCallError]
+        # @raise [ArgumentError]
+        # @return [String]
+        def normalize_path(path)
+          File.realpath(path)
+        rescue SystemCallError, ArgumentError
+          File.expand_path(path)
         end
 
         # Build error offense entry.
@@ -237,6 +241,7 @@ module Docscribe
         def build_offense(change, severity)
           offense = base_offense(change, severity)
           attach_source(offense, change)
+          attach_type(offense, change)
         end
 
         # @private
@@ -261,6 +266,18 @@ module Docscribe
         def attach_source(offense, change)
           source = offense_source(change)
           offense[:source] = source if source
+          offense
+        end
+
+        # Attach machine-readable change type when present.
+        #
+        # @private
+        # @param [Docscribe::CLI::Formatters::Json::json_offense] offense offense hash being built
+        # @param [Docscribe::CLI::Formatters::change] change change info hash
+        # @return [Docscribe::CLI::Formatters::Json::json_offense]
+        def attach_type(offense, change)
+          type = change[:type] || change['type']
+          offense[:type] = type.to_s if type
           offense
         end
 

--- a/lib/docscribe/cli/formatters/sarif.rb
+++ b/lib/docscribe/cli/formatters/sarif.rb
@@ -167,9 +167,21 @@ module Docscribe
             message: { text: message_for(change) },
             locations: [location(path, change[:line] || 1)]
           }
-          source = change[:source] || change['source'] # steep:ignore
-          result[:properties] = { source: source } if source
+          properties = result_properties(change)
+          result[:properties] = properties unless properties.empty?
           result
+        end
+
+        # @private
+        # @param [Docscribe::CLI::Formatters::change] change
+        # @return [Hash<Symbol, String>]
+        def result_properties(change)
+          source = change[:source] || change['source']
+          type = change[:type] || change['type']
+          properties = {}
+          properties[:source] = source if source
+          properties[:type] = type.to_s if type
+          properties
         end
 
         # @private

--- a/sig/lib/docscribe/cli/formatters/json.rbs
+++ b/sig/lib/docscribe/cli/formatters/json.rbs
@@ -8,7 +8,7 @@ module Docscribe
         COP_NAME_MAP: Hash[Symbol, String]
 
         type json_location = { start_line: Integer, start_column: Integer, last_line: Integer, last_column: Integer }
-        type json_offense = { severity: String, cop_name: String, message: String, corrected: bool, correctable: bool, location: json_location, ?source: String }
+        type json_offense = { severity: String, cop_name: String, message: String, corrected: bool, correctable: bool, location: json_location, ?source: String, ?type: String }
         type json_file = { path: String, offenses: Array[json_offense] }
         type json_metadata = { docscribe_version: String, ruby_version: String }
         type json_summary = { offense_count: Integer, target_file_count: Integer, inspected_file_count: Integer, error_count: Integer }
@@ -38,7 +38,7 @@ module Docscribe
 
         def merge_or_append: (Array[json_file] files, String path, Array[json_offense] offenses) -> void
 
-        def file_entry: (String path, Array[change] changes, ?severity: String?) -> json_file
+        def normalize_path: (String path) -> String
 
         def error_offense: (state state, String path) -> json_offense
 
@@ -53,6 +53,8 @@ module Docscribe
         def base_offense: (change change, String? severity) -> json_offense
 
         def attach_source: (json_offense offense, change change) -> json_offense
+
+        def attach_type: (json_offense offense, change change) -> json_offense
 
         def offense_source: (change change) -> (String | nil)
 

--- a/sig/lib/docscribe/cli/formatters/sarif.rbs
+++ b/sig/lib/docscribe/cli/formatters/sarif.rbs
@@ -20,6 +20,8 @@ module Docscribe
         def append_corrected_results: (state, Array[Hash[Symbol, top]]) -> void
         def append_error_results: (state, Array[Hash[Symbol, top]]) -> void
         def build_result: (change, String, ?level: String?) -> Hash[Symbol, top]
+
+        def result_properties: (change) -> Hash[Symbol, String]
         def build_error_result: (String, String) -> Hash[Symbol, top]
         def location: (String, Integer) -> Hash[Symbol, top]
         def cop_name_for: (change) -> String

--- a/spec/docscribe/cli/formatters/json_spec.rb
+++ b/spec/docscribe/cli/formatters/json_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'tmpdir'
 require 'docscribe/cli/formatters'
 
 RSpec.describe Docscribe::CLI::Formatters::Json do
@@ -175,6 +176,81 @@ RSpec.describe Docscribe::CLI::Formatters::Json do
 
     it 'has location with line info' do
       expect(offense['location']).to include('start_line', 'start_column', 'last_line', 'last_column')
+    end
+
+    it 'includes machine-readable type' do
+      expect(offense['type']).to eq('missing_param')
+    end
+  end
+
+  describe 'file grouping' do
+    it 'merges fail and mismatch entries for the same file' do
+      state.merge!(
+        checked_fail: 1,
+        fail_paths: ['dup.rb'],
+        fail_changes: { 'dup.rb' => [{ type: :missing_return, line: 3, method: 'A#foo' }] },
+        type_mismatch_paths: ['dup.rb'],
+        type_mismatch_changes: { 'dup.rb' => [{ type: :updated_return, line: 3, method: 'A#foo' }] }
+      )
+      files = parse_output['files']
+      expect(files.size).to eq(1)
+      expect(files[0]['offenses'].size).to eq(2)
+    end
+
+    it 'merges relative and absolute spellings of one path' do
+      abs = File.expand_path('dup.rb')
+      state.merge!(
+        checked_fail: 1,
+        fail_paths: ['dup.rb', abs],
+        fail_changes: {
+          'dup.rb' => [{ type: :missing_return, line: 3, method: 'A#foo' }],
+          abs => [{ type: :missing_param, line: 4, method: 'A#foo' }]
+        }
+      )
+      files = parse_output['files']
+      expect(files.size).to eq(1)
+      expect(files[0]['offenses'].size).to eq(2)
+    end
+
+    it 'merges ./-prefixed and bare spellings' do
+      state.merge!(
+        checked_fail: 1,
+        fail_paths: ['./dup.rb', 'dup.rb'],
+        fail_changes: {
+          './dup.rb' => [{ type: :missing_return, line: 3, method: 'A#foo' }],
+          'dup.rb' => [{ type: :missing_param, line: 4, method: 'A#foo' }]
+        }
+      )
+      expect(parse_output['files'].size).to eq(1)
+    end
+
+    it 'merges symlinked spellings of one path' do
+      Dir.mktmpdir do |dir|
+        real, link = symlink_pair(dir)
+        state.merge!(
+          checked_fail: 1,
+          fail_paths: [real, link],
+          fail_changes: {
+            real => [{ type: :missing_return, line: 1, method: 'A#foo' }],
+            link => [{ type: :missing_param, line: 1, method: 'A#foo' }]
+          }
+        )
+        expect(parse_output['files'].size).to eq(1)
+        expect(parse_output['files'].first['offenses'].size).to eq(2)
+      end
+    end
+
+    it 'counts merged files once in summary' do
+      state.merge!(
+        checked_fail: 1,
+        fail_paths: ['./dup.rb', 'dup.rb'],
+        fail_changes: {
+          './dup.rb' => [{ type: :missing_return, line: 3, method: 'A#foo' }],
+          'dup.rb' => [{ type: :missing_param, line: 4, method: 'A#foo' }]
+        }
+      )
+      expect(parse_output['summary']['target_file_count']).to eq(1)
+      expect(parse_output['summary']['offense_count']).to eq(2)
     end
   end
 end

--- a/spec/docscribe/cli/formatters/sarif_spec.rb
+++ b/spec/docscribe/cli/formatters/sarif_spec.rb
@@ -135,6 +135,10 @@ RSpec.describe Docscribe::CLI::Formatters::Sarif do
       it 'includes source in properties' do
         expect(results[0]['properties']['source']).to eq('rbs')
       end
+
+      it 'includes type in properties' do
+        expect(results[0]['properties']['type']).to eq('updated_param')
+      end
     end
 
     context 'with errors' do

--- a/spec/docscribe/inline_rewriter/source_propagation_spec.rb
+++ b/spec/docscribe/inline_rewriter/source_propagation_spec.rb
@@ -323,8 +323,8 @@ RSpec.describe Docscribe::InlineRewriter do
       end
       let(:sarif_result_without_source) { parsed_sarif_without_source['runs'][0]['results'][0] }
 
-      it 'omits properties when no source in SARIF' do
-        expect(sarif_result_without_source).not_to have_key('properties')
+      it 'includes type without source in SARIF properties' do
+        expect(sarif_result_without_source['properties']).to eq('type' => 'missing_return')
       end
     end
 

--- a/spec/support/formatter_helper.rb
+++ b/spec/support/formatter_helper.rb
@@ -37,6 +37,18 @@ module FormatterHelper
     parsed['runs'][0]['results'][0]
   end
 
+  # Build a real file plus a symlink pointing at it.
+  #
+  # @param [String] dir existing directory for both entries
+  # @return [Array<String>] real path and symlink path
+  def symlink_pair(dir)
+    real = File.join(dir, 'real.rb')
+    link = File.join(dir, 'link.rb')
+    File.write(real, "def foo\nend\n")
+    File.symlink(real, link)
+    [real, link]
+  end
+
   # Build a base state with a single fail change containing source.
   #
   # @param [String] source source identifier


### PR DESCRIPTION
## Summary

Makes machine-readable output more useful for IDE routing and fixes inflated file lists: every JSON offense and SARIF result now carries the change `type` (`updated_return`, `missing_param`, …) alongside `source`, and the JSON formatter merges entries that refer to the same file under different spellings (absolute vs relative, `./`-prefixed, symlinked paths like `/tmp` vs `/private/tmp` on macOS), so `files[]` and `target_file_count` no longer double-count.

## Changes

- `lib/docscribe/cli/formatters/json.rb`: new `attach_type` (mirrors `attach_source`, conditional on presence); `append_check_files` routes through `merge_or_append`; new `normalize_path` (`File.realpath` with `expand_path` fallback) used for dedup comparison, first-seen spelling kept; removed now-unused `file_entry`.
- `lib/docscribe/cli/formatters/sarif.rb`: `properties` now include `type` next to `source` (extracted into `result_properties` to stay within complexity budgets).
- `sig/.../json.rbs`, `sig/.../sarif.rbs`: `?type: String` on the offense type, new method declarations, `file_entry` removed.
- Specs: `type` assertions for JSON/SARIF; grouping cases (fail+mismatch merge, relative/absolute, `./` spellings, real symlink pair via `symlink_pair` in `formatter_helper.rb` — spec files stay `subject`/`let`-only).

## Verification

- [x] `bundle exec rspec` passes (148/148 formatter + run suites)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)

Live-checked on the branch: `--format json` on a file passed as both absolute and relative paths yields one entry with merged offenses and `target_file_count: 1` (was 2/4 split before).