### PR TITLE
[1.6.2] Infer `Hash` `key`/`value` types for `to_h` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,25 @@
 
 ### Fixed
 
+- **`docscribe config` crash** — the `config` subcommand died with `LoadError` (`cannot load such file --
+  docscribe/cli/config`); dispatch now maps `config → config_dump`, with a regression spec covering all 9
+  subcommands.
+- **`docscribe-client --status` always `not_running`** — the liveness check relied on `UNIXSocket#close`
+  return value (`nil`); now a successful connect means alive, missing/stale socket means not running.
+- **Missing-collection warning on plain runs** — the `rbs_collection.lock.yaml` nudge now fires without any
+  CLI flags (previously gated behind unrelated overrides), in both CLI and daemon paths.
+- **`--no-validate-types` ignored** — explicit negation now overrides `validate_types: true` from
+  `docscribe.yml` (the default is "not passed", not `false`); audit showed it is the only `--[no-]` flag,
+  and `update_types` forwards the negation to both passes.
+- **Duplicate files in JSON output** — the same file passed under different spellings (absolute, relative,
+  `./`-prefixed, symlinked `/tmp` vs `/private/tmp`) produced several entries and inflated
+  `target_file_count`; entries are now merged by normalized path.
+- **Machine-readable `type` in JSON/SARIF** — every offense/result carries `type` (`updated_return`,
+  `missing_param`, …) alongside `source`, so IDE plugins no longer have to parse it out of `cop_name`.
+- **Block-form `to_h` inference** — `arr.each_with_index.to_h { |x, i| ... }` infers `Hash<K, V>` from the
+  pair literal (second block parameter is always the `Integer` index) instead of a bare `Array`;
+  uninferrable types are honestly reported as `Object` instead of a guessed `String` (same for the
+  send-form fallback).
 - **Conditional `@return [X] if Error` no longer overwrites the main return type** — kills the check/update_types
   ping-pong.
 - **Fallback rescue types are not emitted as noise** — bare `Object` conditionals are skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 - **`rbs.collection: true` honored without flags** — plain `check` (CLI, daemon, IDE) auto-discovers the RBS
   collection from `rbs_collection.lock.yaml`, same as `--rbs-collection`.
 - **Rescue-branch constant resolution** — rescue bodies referencing constants (e.g. `FALLBACK_TYPE`) infer the
-  constant's value type when visible from the method's scope.
+  constant's value type when it is loaded in the running process (runtime-visible via the method's scope);
+  constants that exist only in analyzed files fall back to the constant name. Static project-wide resolution
+  is planned for 1.7.0.
 - **Per-method failure isolation** — a crashing method is skipped with a stderr warning instead of blanking
   the whole file.
 

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ How it works, briefly: the IDE annotator collects file info on open/type/save, a
 
 Version gates (plugin behavior by gem version):
 
-| Gem version | Plugin behavior |
-|---|---|
-| `< 1.5.1` | always CLI, no daemon mode |
-| `< 1.5.2` | no batch mode (workspace check scans the directory via CLI) |
-| `< 1.6.2` | `update_types` falls back to CLI on unknown method |
+| Gem version | Plugin behavior                                             |
+|-------------|-------------------------------------------------------------|
+| `< 1.5.1`   | always CLI, no daemon mode                                  |
+| `< 1.5.2`   | no batch mode (workspace check scans the directory via CLI) |
+| `< 1.6.2`   | `update_types` falls back to CLI on unknown method          |
 
 ## CLI
 
@@ -276,6 +276,10 @@ If you pass no files and don't use `--stdin`, Docscribe processes the current di
 - `--format FORMAT`  
   Output format: `text` (default, human-readable), `json` (machine-readable, RuboCop-compatible), or `sarif` (SARIF 2.1
   JSON, compatible with GitHub Code Scanning).
+  Every JSON offense carries `cop_name`, `message`, `location`, plus machine-readable `type`
+  (`updated_return`, `missing_param`, ...) and, for type mismatches, `source` (`"rbs"`, `"infer"` or `"syntax"`).
+  Files are grouped by normalized path, so the same file passed under different spellings
+  (absolute, relative, symlinked) appears once.
 
 - `--rbs`  
   Use RBS signatures for `@param`/`@return` when available (falls back to inference).
@@ -1180,7 +1184,9 @@ Return values:
 - For control flow (`if`/`case`), it unifies branches conservatively.
 - Blocks resolve to generics where possible: `map`/`then` over known elements give `Array<String>` instead of
   bare `Array`; `arr << x` and `x += 1` resolve through RBS (`self`-returns stay `self`); `&.`/`||`/`()` receivers
-  are unwrapped before lookup; `each_with_index` chains infer `Enumerator`/`Hash` element types.
+  are unwrapped before lookup; `each_with_index` chains infer `Enumerator`/`Hash` element types
+  (`arr.each_with_index.to_h { |x, i| [k, v] }` infers `Hash<K, V>` from the pair literal;
+  the second block parameter is always the `Integer` index).
 - Generic compatibility is structural, not textual: `Hash` matches `Hash<Symbol, Config>`, `Array` matches
   `Array<String>`, `String?` equals `String, nil` and `String|nil`, and `String` is accepted where `Object` is
   expected. YARD `[]` and RBS `<>` (plus `untyped`/`Object`) are normalized before comparison.

--- a/lib/docscribe/cli/run.rb
+++ b/lib/docscribe/cli/run.rb
@@ -793,18 +793,23 @@ module Docscribe
         # @return [void]
         def handle_validated_type_mismatch(path, file_changes, type_mismatches, ctx)
           handle_failed_check(path, file_changes, ctx)
-          track_validated_mismatch(type_mismatches, ctx)
+          # Drop the records the tracker already holds: the same mismatch must
+          # not appear (and count) twice in JSON output.
+          stored = ctx[:state][:fail_changes][path] || []
+          ctx[:state][:fail_changes][path] = stored - type_mismatches
+          track_validated_mismatch(type_mismatches, ctx, path)
         end
 
         # @private
         # @param [Array<Docscribe::CLI::Formatters::change>] type_mismatches
         # @param [Docscribe::CLI::Run::run_ctx] ctx
+        # @param [String] path raw file path, used as the map key so fail and
+        #   mismatch entries merge in JSON output
         # @return [void]
-        def track_validated_mismatch(type_mismatches, ctx)
+        def track_validated_mismatch(type_mismatches, ctx, path)
           state = ctx[:state]
-          display_path = ctx[:display_path]
-          state[:type_mismatch_paths] << display_path unless state[:type_mismatch_paths].include?(display_path)
-          state[:type_mismatch_changes][display_path] = type_mismatches
+          state[:type_mismatch_paths] << path unless state[:type_mismatch_paths].include?(path)
+          state[:type_mismatch_changes][path] = type_mismatches
         end
 
         # @private

--- a/lib/docscribe/infer/returns.rb
+++ b/lib/docscribe/infer/returns.rb
@@ -786,6 +786,7 @@ module Docscribe
 
         meth = send_node.children[1]
         handle_then_block(node, meth, **opts) ||
+          handle_to_h_block(node, meth, **opts) ||
           block_send_rbs_type(node, send_node, **opts) ||
           handle_map_block(node, meth, **opts) ||
           run_last_expr_type(node.children[2], **opts)
@@ -800,6 +801,125 @@ module Docscribe
         return nil unless %i[then yield_self].include?(meth)
 
         run_last_expr_type(node.children[2], **opts)
+      end
+
+      # @note module_function: defines #handle_to_h_block (visibility: private)
+      # @param [Parser::AST::Node] node
+      # @param [Symbol] meth
+      # @param [Hash] opts
+      # @return [String, nil]
+      def handle_to_h_block(node, meth, **opts)
+        return nil unless meth == :to_h
+
+        recv = to_h_each_recv(node)
+        return nil unless recv
+
+        key, value = to_h_key_value(node, recv, **opts)
+        "Hash<#{key}, #{value}>"
+      end
+
+      # Receiver of `to_h` when it chains off `each_with_index`.
+      #
+      # @note module_function: defines #to_h_each_recv (visibility: private)
+      # @param [Parser::AST::Node] node block node
+      # @return [Parser::AST::Node, nil]
+      def to_h_each_recv(node)
+        send_node = node.children[0]
+        recv = send_node.children[0]
+        recv if recv&.type == :send && recv.children[1] == :each_with_index
+      end
+
+      # Resolve key/value types for a `to_h` block.
+      #
+      # @note module_function: defines #to_h_key_value (visibility: private)
+      # @param [Parser::AST::Node] node block node
+      # @param [Parser::AST::Node] recv `each_with_index` send node
+      # @param [Hash] opts additional keyword options forwarded to type inference
+      # @return [(String, String)]
+      def to_h_key_value(node, recv, **opts)
+        body = node.children[2]
+        key, value = to_h_block_pair_types(body, block_arg_names(node), **opts)
+        key ||= hash_elem_from_enumerator(recv.children[0], **opts)
+        key = 'Object' if unknown_type?(key)
+        value ||= pair_literal?(body) ? 'Object' : 'Integer'
+        [key, value]
+      end
+
+      # Names of the block parameters, if any.
+      #
+      # @note module_function: defines #block_arg_names (visibility: private)
+      # @param [Parser::AST::Node] node block node
+      # @return [Array<String>]
+      def block_arg_names(node)
+        args = node.children[1]
+        return [] unless args&.type == :args
+
+        args.children.filter_map { |a| a.children[0]&.to_s }
+      end
+
+      # Infer key/value types from a `[k, v]` pair literal block body.
+      #
+      # A bare `lvar` matching an `each_with_index` block parameter resolves
+      # structurally: first parameter is the element (resolved from the receiver
+      # by the caller), second parameter is always the Integer index.
+      #
+      # @note module_function: defines #to_h_block_pair_types (visibility: private)
+      # @param [Parser::AST::Node?] body block body node
+      # @param [Array<String>] arg_names block parameter names
+      # @param [Hash] opts additional keyword options forwarded to type inference
+      # @return [(String, nil, String, nil)] inferred key and value types, nil when unavailable
+      def to_h_block_pair_types(body, arg_names, **opts)
+        return [nil, nil] unless pair_literal?(body)
+
+        pair = body.type == :begin ? body.children.last : body
+        [pair_elem_type(pair.children[0], arg_names, 0, **opts),
+         pair_elem_type(pair.children[1], arg_names, 1, **opts)]
+      end
+
+      # Whether the block body is a `[k, v]` pair literal.
+      #
+      # @note module_function: defines #pair_literal? (visibility: private)
+      # @param [Parser::AST::Node?] body block body node
+      # @return [Boolean]
+      def pair_literal?(body)
+        body = body.children.last if body&.type == :begin
+        body&.type == :array && body.children.size == 2
+      end
+
+      # Infer one pair element, honoring block parameter positions.
+      #
+      # @note module_function: defines #pair_elem_type (visibility: private)
+      # @param [Parser::AST::Node?] node element node
+      # @param [Array<String>] arg_names block parameter names
+      # @param [Integer] position 0 for key, 1 for value
+      # @param [Hash] opts additional keyword options forwarded to type inference
+      # @return [String, nil]
+      def pair_elem_type(node, arg_names, position, **opts)
+        if node&.type == :lvar && node.children[0].to_s == arg_names[position]
+          return position == 1 ? 'Integer' : nil
+        end
+
+        infer_pair_elem(node, **opts)
+      end
+
+      # Infer one pair element type, normalizing unknown to nil.
+      #
+      # @note module_function: defines #infer_pair_elem (visibility: private)
+      # @param [Parser::AST::Node?] node element node
+      # @param [Hash] opts additional keyword options forwarded to type inference
+      # @return [String, nil]
+      def infer_pair_elem(node, **opts)
+        type = run_last_expr_type(node, **opts)
+        type unless unknown_type?(type)
+      end
+
+      # Whether a type string means "could not determine".
+      #
+      # @note module_function: defines #unknown_type? (visibility: private)
+      # @param [String, nil] type inferred type string
+      # @return [Boolean]
+      def unknown_type?(type)
+        type.nil? || %w[Object untyped nil].include?(type)
       end
 
       # @note module_function: defines #handle_map_block (visibility: private)
@@ -1058,7 +1178,7 @@ module Docscribe
         return unless meth == :to_h && recv && recv.type == :send && recv.children[1] == :each_with_index
 
         inner_recv = recv.children[0]
-        elem = hash_elem_from_enumerator(inner_recv, **opts) || 'String'
+        elem = hash_elem_from_enumerator(inner_recv, **opts) || 'Object'
         "Hash<#{elem}, Integer>"
       end
 

--- a/lib/docscribe/infer/returns.rb
+++ b/lib/docscribe/infer/returns.rb
@@ -219,7 +219,7 @@ module Docscribe
         name, value = assignment_name_and_value(node)
         return unless name && value
 
-        inferred = if node.type == :op_asgn
+        inferred = if %i[op_asgn or_asgn].include?(node.type)
                      assignment_op_asgn_type(node, types, **opts)
                    else
                      assignment_inferred_type(value, types, **opts)
@@ -252,7 +252,7 @@ module Docscribe
       # Extract the variable name and value expression from an assignment node.
       #
       # @note module_function: defines #assignment_name_and_value (visibility: private)
-      # @param [Parser::AST::Node] node an assignment AST node (:lvasgn, :gvasgn, :ivasgn, :casgn, :op_asgn)
+      # @param [Parser::AST::Node] node an assignment AST node (:lvasgn, :gvasgn, :ivasgn, :casgn, :op_asgn, :or_asgn)
       # @return [(String, nil, Parser::AST::Node, nil)]
       def assignment_name_and_value(node)
         return [nil, nil] unless node.is_a?(Parser::AST::Node)
@@ -261,6 +261,7 @@ module Docscribe
         when :lvasgn, :gvasgn, :ivasgn, :cvasgn then [node.children[0].to_s, node.children[1]]
         when :casgn then constant_name_and_value(node)
         when :op_asgn then compound_name_and_value(node)
+        when :or_asgn then or_asgn_name_and_value(node)
         else [nil, nil]
         end
       end
@@ -281,6 +282,21 @@ module Docscribe
       # @return [(String, nil, Parser::AST::Node, nil)]
       def compound_name_and_value(node)
         [node.children[0].children.first.to_s, node.children[2]]
+      end
+
+      # Extract the name and value from an `:or_asgn` (`||=`) node.
+      #
+      # Unlike `:op_asgn` (three children: target, operator, value), `:or_asgn`
+      # carries only target and value.
+      #
+      # @note module_function: defines #or_asgn_name_and_value (visibility: private)
+      # @param [Parser::AST::Node] node the `:or_asgn` AST node
+      # @return [(String, nil, Parser::AST::Node, nil)]
+      def or_asgn_name_and_value(node)
+        target = node.children[0]
+        return [nil, nil] unless target.is_a?(Parser::AST::Node)
+
+        [target.children.first.to_s, node.children[1]]
       end
 
       # Handle `:lvar` node for last_expr_type — look up the variable in local_var_types.
@@ -572,14 +588,47 @@ module Docscribe
         fallback = opts[:fallback_type] || 'untyped'
         # If one side is the fallback alias (FALLBACK_TYPE / fallback_type) and the other is concrete, prefer the concrete
         # This prevents `sig&.return_type || FALLBACK_TYPE` from becoming `String, Object` when String is known
-        if fallback_alias?(t, fallback) && !fallback_alias?(e, fallback)
-          return e
-        elsif fallback_alias?(e, fallback) && !fallback_alias?(t, fallback)
-          return t
-        end
+        preferred = or_prefer_concrete(t, e, fallback)
+        return preferred if preferred
 
         unify_types(t, e, fallback_type: fallback,
                           nil_as_optional: opts.fetch(:nil_as_optional, true))
+      end
+
+      # Handle `:or_asgn` node (`x ||= y`) for last_expr_type.
+      #
+      # Same type semantics as `||`: the assignment target counts as the left
+      # side, so an unknown receiver with a concrete literal right-hand side
+      # (e.g. `@h ||= Hash.new`) infers the literal type.
+      #
+      # @note module_function: defines #handle_or_asgn_node (visibility: private)
+      # @param [Parser::AST::Node] node the `:or_asgn` AST node
+      # @param [Hash] opts additional keyword options forwarded to type inference
+      # @return [String, nil]
+      def handle_or_asgn_node(node, **opts)
+        t = run_last_expr_type(node.children[0], **opts)
+        e = run_last_expr_type(node.children[1], **opts)
+        fallback = opts[:fallback_type] || 'untyped'
+        preferred = or_prefer_concrete(t, e, fallback)
+        return preferred if preferred
+
+        unify_types(t, e, fallback_type: fallback,
+                          nil_as_optional: opts.fetch(:nil_as_optional, true))
+      end
+
+      # Prefer the concrete side when the other is a fallback alias.
+      #
+      # @note module_function: defines #or_prefer_concrete (visibility: private)
+      # @param [String, nil] left_type left side inferred type
+      # @param [String, nil] right_type right side inferred type
+      # @param [String] fallback fallback type name
+      # @return [String, nil] preferred side or nil when neither applies
+      def or_prefer_concrete(left_type, right_type, fallback)
+        if fallback_alias?(left_type, fallback) && !fallback_alias?(right_type, fallback)
+          right_type
+        elsif fallback_alias?(right_type, fallback) && !fallback_alias?(left_type, fallback)
+          left_type
+        end
       end
 
       # Handle `:and` node (`a && b`) for last_expr_type.

--- a/sig/lib/docscribe/cli/run.rbs
+++ b/sig/lib/docscribe/cli/run.rbs
@@ -100,7 +100,7 @@ module Docscribe
 
       def self.handle_validated_type_mismatch: (String path, Array[Formatters::change] file_changes, Array[Formatters::change] type_mismatches, run_ctx ctx) -> void
 
-      def self.track_validated_mismatch: (Array[Formatters::change] type_mismatches, run_ctx ctx) -> void
+      def self.track_validated_mismatch: (Array[Formatters::change] type_mismatches, run_ctx ctx, String path) -> void
 
       def self.handle_no_changes: (String path, Array[Formatters::change] type_mismatches, run_ctx ctx) -> void
 

--- a/sig/lib/docscribe/infer/returns.rbs
+++ b/sig/lib/docscribe/infer/returns.rbs
@@ -309,6 +309,24 @@ module Docscribe
 
       def self?.handle_map_block: (Parser::AST::Node node, Symbol meth, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
 
+      def self?.handle_to_h_block: (Parser::AST::Node node, Symbol meth, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
+
+      def self?.to_h_each_recv: (Parser::AST::Node node) -> (Parser::AST::Node | nil)
+
+      def self?.to_h_key_value: (Parser::AST::Node node, Parser::AST::Node recv, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> [String, String]
+
+      def self?.block_arg_names: (Parser::AST::Node node) -> Array[String]
+
+      def self?.pair_literal?: (Parser::AST::Node? body) -> bool
+
+      def self?.to_h_block_pair_types: (Parser::AST::Node? body, Array[String] arg_names, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> [(String | nil), (String | nil)]
+
+      def self?.pair_elem_type: (Parser::AST::Node? node, Array[String] arg_names, Integer position, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
+
+      def self?.infer_pair_elem: (Parser::AST::Node? node, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
+
+      def self?.unknown_type?: ((String | nil) type) -> bool
+
       def self?.block_generic_substitution: (String rbs_type, (String | nil) inner) -> (String | nil)
 
       def self?.placeholder_tokens: (String inner_generic) -> Array[String]

--- a/sig/lib/docscribe/infer/returns.rbs
+++ b/sig/lib/docscribe/infer/returns.rbs
@@ -55,6 +55,12 @@ module Docscribe
 
       def self?.handle_or_node: (Parser::AST::Node node, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
 
+      def self?.handle_or_asgn_node: (Parser::AST::Node node, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
+
+      def self?.or_prefer_concrete: ((String | nil) t, (String | nil) e, String fallback) -> (String | nil)
+
+      def self?.or_asgn_name_and_value: (Parser::AST::Node node) -> [(String | nil), (Parser::AST::Node | nil)]
+
       def self?.handle_and_node: (Parser::AST::Node node, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)
 
       def self?.handle_kwbegin_node: (Parser::AST::Node node, ?fallback_type: String?, ?nil_as_optional: bool, ?core_rbs_provider: Types::RBS::Provider?, ?param_types: Hash[String, String]?, ?container: String?, ?signature_provider: Types::ProviderChain?, ?local_var_types: Hash[String, String]?) -> (String | nil)

--- a/spec/docscribe/cli/formatters/json_spec.rb
+++ b/spec/docscribe/cli/formatters/json_spec.rb
@@ -252,5 +252,19 @@ RSpec.describe Docscribe::CLI::Formatters::Json do
       expect(parse_output['summary']['target_file_count']).to eq(1)
       expect(parse_output['summary']['offense_count']).to eq(2)
     end
+
+    it 'does not duplicate validated mismatches stored without fail changes', :aggregate_failures do
+      state.merge!(
+        checked_fail: 1,
+        fail_paths: ['dup.rb'],
+        fail_changes: { 'dup.rb' => [] },
+        type_mismatch_paths: ['dup.rb'],
+        type_mismatch_changes: { 'dup.rb' => [{ type: :updated_return, line: 3, method: 'A#foo' }] }
+      )
+      files = parse_output['files']
+      expect(files.size).to eq(1)
+      expect(files[0]['offenses'].size).to eq(1)
+      expect(parse_output['summary']['offense_count']).to eq(1)
+    end
   end
 end

--- a/spec/docscribe/cli/run_spec.rb
+++ b/spec/docscribe/cli/run_spec.rb
@@ -396,6 +396,41 @@ RSpec.describe Docscribe::CLI::Run do
     end
   end
 
+  describe '.handle_validated_type_mismatch' do
+    subject(:handle) do
+      described_class.send(:handle_validated_type_mismatch, 'a.rb', changes, changes, ctx)
+    end
+
+    let(:changes) { [{ type: :updated_return, line: 3, method: 'A#foo' }] }
+    let(:state) do
+      { checked_fail: 0, changed: false, fail_paths: [], fail_changes: {},
+        type_mismatch_paths: [], type_mismatch_changes: {} }
+    end
+    let(:ctx) { { display_path: 'shown/a.rb', options: { verbose: false }, state: state } }
+
+    it 'counts the failure and keeps the path listed', :aggregate_failures do
+      handle
+      expect(state[:checked_fail]).to eq(1)
+      expect(state[:changed]).to be(true)
+      expect(state[:fail_paths]).to eq(['a.rb'])
+    end
+
+    it 'drops tracked records from fail changes' do
+      handle
+      expect(state[:fail_changes]).to eq({ 'a.rb' => [] })
+    end
+
+    it 'tracks mismatches once, keyed by raw path' do
+      handle
+      expect(state[:type_mismatch_paths]).to eq(['a.rb'])
+      expect(state[:type_mismatch_changes]).to eq({ 'a.rb' => changes })
+    end
+
+    it 'prints the failure marker' do
+      expect { handle }.to output('F').to_stderr
+    end
+  end
+
   describe '.extract_cli_overrides' do
     context 'when options contain false values' do
       subject(:overrides) { described_class.send(:extract_cli_overrides, options) }

--- a/spec/docscribe/infer/fallback_and_block_spec.rb
+++ b/spec/docscribe/infer/fallback_and_block_spec.rb
@@ -163,6 +163,56 @@ RSpec.describe Docscribe::Infer::Returns do
     end
   end
 
+  describe 'handle_or_asgn node (||=)' do
+    subject(:inferred) { described_class.infer_return_type(code) }
+
+    context 'with Hash.new literal and later read' do
+      let(:code) do
+        <<~RUBY
+          def foo
+            @h ||= Hash.new
+            @h
+          end
+        RUBY
+      end
+
+      it 'infers Hash', :aggregate_failures do
+        expect(inferred).to eq('Hash')
+        expect(inferred).not_to eq('Object')
+      end
+    end
+
+    context 'with Integer literal as last expression' do
+      let(:code) do
+        <<~RUBY
+          def foo
+            @n ||= 1
+          end
+        RUBY
+      end
+
+      it 'infers Integer' do
+        expect(inferred).to eq('Integer')
+      end
+    end
+
+    context 'with already typed ivar' do
+      let(:code) do
+        <<~RUBY
+          def foo
+            @s = 'x'
+            @s ||= 'y'
+            @s
+          end
+        RUBY
+      end
+
+      it 'keeps String' do
+        expect(inferred).to eq('String')
+      end
+    end
+  end
+
   describe 'block RBS Array<String> via handle_block_node' do
     context 'when block has RBS type containing U/Elem and inner type' do
       subject(:output) { inline(code, config: config) }

--- a/spec/docscribe/infer/synthetic_chain_spec.rb
+++ b/spec/docscribe/infer/synthetic_chain_spec.rb
@@ -27,6 +27,59 @@ RSpec.describe Docscribe::Infer::Returns do
         expect(inferred).not_to eq('Hash<Object, Object>')
       end
     end
+
+    context 'when chain is each_with_index.to_h with a block' do
+      let(:method_source) do
+        'def foo(arr); arr.each_with_index.to_h { |x, i| [x.to_s, i] }; end'
+      end
+
+      it 'infers Hash not Array', :aggregate_failures do
+        expect(inferred).to eq('Hash<String, Integer>')
+        expect(inferred).not_to eq('Array')
+      end
+    end
+
+    context 'when to_h block follows a map chain' do
+      let(:method_source) do
+        'def foo(tag_order); Array(tag_order).map { |t| t.to_s }.each_with_index.to_h { |x, i| [x, i] }; end'
+      end
+
+      it 'infers Hash<String, Integer>', :aggregate_failures do
+        expect(inferred).to eq('Hash<String, Integer>')
+        expect(inferred).not_to eq('Hash<Object, Object>')
+      end
+    end
+
+    context 'when to_h block transforms both pair elements' do
+      let(:method_source) do
+        'def foo(arr); arr.each_with_index.to_h { |x, i| [x.to_s, i.to_s] }; end'
+      end
+
+      it 'infers Hash<String, String>' do
+        expect(inferred).to eq('Hash<String, String>')
+      end
+    end
+
+    context 'when to_h block pair cannot be inferred' do
+      let(:method_source) do
+        'def foo(arr); arr.each_with_index.to_h { |x, i| [x.foo, y.bar] }; end'
+      end
+
+      it 'falls back to Hash<Object, Object>' do
+        expect(inferred).to eq('Hash<Object, Object>')
+      end
+    end
+
+    context 'when to_h block body is not a pair' do
+      let(:method_source) do
+        'def foo(arr); arr.each_with_index.to_h { |x, i| x.to_s }; end'
+      end
+
+      it 'uses receiver elem and Integer index', :aggregate_failures do
+        expect(inferred).to eq('Hash<Object, Integer>')
+        expect(inferred).not_to eq('Array')
+      end
+    end
   end
 
   describe '.run_last_expr_type integration' do


### PR DESCRIPTION
## Summary

Type-inference improvements plus a JSON counting fix: block-form `to_h` chains infer `Hash<K, V>`, `||=` assignments infer literal types, and validated type mismatches no longer inflate `offense_count`. Also includes the 1.6.2 CHANGELOG/README updates and a documented limitation on rescue-constant resolution.

## Changes

- `lib/docscribe/infer/returns.rb`:
  - New `handle_to_h_block`: `arr.each_with_index.to_h { |x, i| ... }` infers `Hash<K, V>` from the `[k, v]` pair literal (second block parameter is always the `Integer` index, first resolves from the receiver); uninferrable sides honestly become `Object`; send-form fallback changed `'String'` -> `'Object'`.
  - New `handle_or_asgn_node` (plus `or_asgn_name_and_value` and assignment tracking): `@h ||= Hash.new` infers `Hash`, sharing the `||` preference logic via extracted `or_prefer_concrete` (also reused by `handle_or_node`).
- `lib/docscribe/cli/run.rb`: validated mismatches are no longer stored in both `fail_changes` and the mismatch tracker (same finding counted twice); the tracker is keyed by raw path so entries merge in JSON output.
- `sig/.../returns.rbs`, `sig/.../run.rbs`: declarations for the new methods.
- `CHANGELOG.md`: 1.6.2 `Fixed` entries; rescue-constant resolution narrowed to runtime-visible constants (static resolution deferred).
- `README.md`: `type` field and file grouping in `--format` docs, block-form `to_h` in inference docs.
- Specs: 5 new `to_h` block contexts, 3 new `||=` contexts, validated-mismatch no-duplicate cases; `symlink_pair` test helper in `formatter_helper.rb`.

## Verification

- [x] `bundle exec rspec` passes (2057/2057, 3 pre-existing pendings)
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec docscribe lib -C docscribe.yml` — OK
- [x] `bundle exec steep check` — no new warnings (Ruby ≥ 3.2)

Live-checked: block-form `to_h` documents `Hash<String, Integer>` (was `Array`); `@h ||= Hash.new` documents `Hash` (was `Object`); same file under different spellings yields one JSON entry with a correct `offense_count`.